### PR TITLE
Simple Vagrantfile for the OL8 container-tools module

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,6 @@
 # The last matching pattern has the most precedence.
 *                         @gvenzl
+/ContainerTools/          @AmedeeBulle          
 /OLCNE/                   @Djelibeybi
 /OracleDatabase/          @gvenzl
 /OracleLinux/             @scoter-oracle

--- a/ContainerTools/LICENSE
+++ b/ContainerTools/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2020 Oracle and/or its affiliates.
+
+The Universal Permissive License (UPL), Version 1.0
+
+Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this
+software, associated documentation and/or data (collectively the "Software"), free of charge and under any and
+all copyright rights in the Software, and any and all patent rights owned or freely licensable by each licensor
+hereunder covering either (i) the unmodified Software as contributed to or provided by such licensor, or
+(ii) the Larger Works (as defined below), to deal in both
+
+(a) the Software, and
+(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software
+(each a “Larger Work” to which the Software is contributed by such licensors),
+
+without restriction, including without limitation the rights to copy, create derivative works of, display,
+perform, and distribute the Software and make, use, sell, offer for sale, import, export, have made, and have
+sold the Software and the Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
+
+This license is subject to the following condition:
+The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must
+be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.

--- a/ContainerTools/README.md
+++ b/ContainerTools/README.md
@@ -1,0 +1,28 @@
+# Vagrantfile to set up Oracle Linux 8 with Container Tools
+A Vagrantfile that installs and configures the Container Tools module on Oracle Linux 8.
+
+This module provides the tools to use container runtimes. That is: mainly Podman, but also Buildah, Skopeo...
+
+## Prerequisites
+1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+1. Install [Vagrant](https://vagrantup.com/)
+
+## Getting started
+1. Clone this repository `git clone https://github.com/oracle/vagrant-boxes`
+1. Change into the `vagrant-boxes/ContainerTools` folder
+1. Run `vagrant up; vagrant ssh`
+1. Within the guest, run Podman commands, for example `podman run -it oraclelinux:7-slim` to run an Oracle Linux 7 container, or `podman run -ti oraclelinux:8-slim` to run an Oracle Linux 8 container
+
+## Optional plugins
+When installed, this Vagrantfile will make use of the following third party Vagrant plugin:
+- [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
+proxies in the guest VMs if you need to access the Internet through proxy. See
+plugin documentation for the configuration.
+
+To intall Vagrant plugins run:
+```
+vagrant plugin install <name>...
+```
+
+## Feedback
+Please provide feedback of any kind via Github issues on this repository.

--- a/ContainerTools/Vagrantfile
+++ b/ContainerTools/Vagrantfile
@@ -1,0 +1,85 @@
+#
+# Vagrantfile for Container Tools
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# Description: Creates an Container Tools environment on Oracle Linux 8
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+# Box metadata location and box name
+BOX_URL = "https://oracle.github.io/vagrant-boxes/boxes"
+BOX_NAME = "oraclelinux/8"
+
+# define hostname
+NAME = "ol8-podman"
+
+# Convenience function -- Ensure URL has a scheme
+def ensure_scheme(url)
+  (url =~ /.*:\/\// ? '' : 'http://') + url
+end
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = BOX_NAME
+  config.vm.box_url = "#{BOX_URL}/#{BOX_NAME}.json"
+  config.vm.define NAME
+
+  # Set proxies if vagrant-proxyconf is installed
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+    ["http_proxy", "HTTP_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        puts "HTTP proxy: " + proxy
+        config.proxy.http = ensure_scheme(proxy)
+        break
+      end
+    end
+
+    ["https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        puts "HTTPS proxy: " + proxy
+        config.proxy.https = ensure_scheme(proxy)
+        break
+      end
+    end
+
+    # We should not proxy local IPs (Container bridges, ...)
+    # Unfortunately we can't use CIDR with no_proxy, so we have to enumerate and
+    # 'blacklist' *all* IPs
+    no_proxy = ''
+    ["no_proxy", "NO_PROXY"].each do |proxy_var|
+      if ENV[proxy_var]
+        no_proxy = ENV[proxy_var]
+        puts "No proxy: " + no_proxy
+        no_proxy += ','
+        break
+      end
+    end
+    config.proxy.no_proxy = no_proxy + "localhost,.vagrant.vm," + (".0"..".255").to_a.join(",")
+  end
+
+  # change memory size
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+    v.name = NAME
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = 2048
+  end
+
+
+  # VM hostname
+  config.vm.hostname = NAME + ".vagrant.vm"
+
+  # Provision everything on the first run
+  config.vm.provision "shell", path: "scripts/install.sh"
+
+  end

--- a/ContainerTools/scripts/install.sh
+++ b/ContainerTools/scripts/install.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Vagrant ContainerTools provisioning script
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# Description: Installs Container Tools OL8 module
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+echo 'Installing Container Tools module'
+
+dnf -y module install container-tools
+
+echo 'Container Tools are ready to use'
+echo 'To get started, on your host, run:'
+echo '  vagrant ssh'
+echo
+echo 'Then, within the guest (for example):'
+echo '  podman run -it --rm oraclelinux:8-slim'
+echo


### PR DESCRIPTION
Introduce a simple Vagrantfile based on the Oracle Linux 8 box with the `container-tools` installed.

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>