### PR TITLE
APEX project - add libvirt provider support

### DIFF
--- a/OracleAPEX/README.md
+++ b/OracleAPEX/README.md
@@ -1,26 +1,29 @@
 # oracle-18c-apex
-A vagrant box that provisions Oracle Database XE 18.4 with Oracle Application Expres (APEX) automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
+
+This Vagrant project provisions Oracle Database XE 18.4 with Oracle Application Express (APEX) automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
 
 ## Prerequisites
-1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-2. Install [Vagrant](https://vagrantup.com/)
+
+Read the [prerequisites in the top level README](../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
 
 ## Getting started
-1. Clone this repository `git clone https://github.com/oracle/vagrant-boxes`
-2. Change into the OracleAPEX folder
-3. Download the Oracle Database XE 18.4 installation rpm file from OTN into this folder - first time only:
+
+1. Clone this repository `git clone https://github.com/oracle/vagrant-projects`
+1. Change into the `vagrant-projects/OracleAPEX` directory
+1. Download the Oracle Database XE 18.4 installation rpm file from OTN into this directory - first time only:
 [https://www.oracle.com/technetwork/database/database-technologies/express-edition/downloads/index.html](https://www.oracle.com/technetwork/database/database-technologies/express-edition/downloads/index.html)
-4. Download the Oracle APEX into this folder - first time only:
+1. Download the Oracle APEX into this directory - first time only:
 [https://www.oracle.com/tools/downloads/apex-downloads.html](https://www.oracle.com/tools/downloads/apex-downloads.html)
-5. Download Oracle Rest Data Services (ORDS) into this folder - first time only:
+1. Download Oracle Rest Data Services (ORDS) into this directory - first time only:
 [https://www.oracle.com/database/technologies/appdev/rest-data-services-downloads.html](https://www.oracle.com/database/technologies/appdev/rest-data-services-downloads.html)
-4. Run `vagrant up`
-   1. The first time you run this it will provision everything and may take a while. Ensure you have (a good) internet connection as the scripts will update the virtual box to the latest via `yum`.
-   2. The Vagrant file allows for customization, if desired (see [Customization](#customization))
-5. Connect to the database.
-6. You can shut down the box via the usual `vagrant halt` and the start it up again via `vagrant up`.
+1. Run `vagrant up`
+   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the virtual box to the latest via `yum`.
+   1. The Vagrant file allows for customization, if desired (see [Customization](#customization))
+1. Connect to the database.
+1. You can shut down the box via the usual `vagrant halt` and the start it up again via `vagrant up`.
 
 ## Connecting to Oracle
+
 * Hostname: `localhost`
 * Port: `1521`
 * SID: `XE`
@@ -36,9 +39,11 @@ A vagrant box that provisions Oracle Database XE 18.4 with Oracle Application Ex
 * The Oracle installation path is `/opt/oracle/` by default.
 * On the guest OS, the directory `/vagrant` is a shared folder and maps to wherever you have this file checked out.
 
-### Customization
+## Customization
+
 You can customize your Oracle environment by amending the environment variables in the `Vagrantfile` file.
 The following can be customized:
+
 * `ORACLE_CHARACTERSET`: `AL32UTF8`
 * `ORACLE_PWD`: `auto generated`
 * `SYSTEM_TIMEZONE`: `automatically set (see below)`
@@ -47,7 +52,8 @@ The following can be customized:
   * When the host time zone isn't a full hour offset from GMT (e.g., in India and parts of Australia), the guest time zone will be set to UTC.
   * You can specify a different time zone using a time zone name (e.g., "America/Los_Angeles") or an offset from GMT (e.g., "Etc/GMT-2"). For more information on specifying time zones, see [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
-### Oracle Application Express Access
+## Oracle Application Express Access
+
 Oracle Application Express Access will be available on the host OS by accessing following URL:
 
 * `http://localhost:8080/ords/`

--- a/OracleAPEX/Vagrantfile
+++ b/OracleAPEX/Vagrantfile
@@ -94,6 +94,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.memory = 2048
     v.name = NAME
   end
+  config.vm.provider :libvirt do |v|
+    v.memory = 2048
+  end
 
   # add proxy configuration from host env - optional
   if Vagrant.has_plugin?("vagrant-proxyconf")
@@ -112,7 +115,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   # VM hostname
-  config.vm.hostname = NAME
+  # must be "localhost", or listener configuration will fail
+  config.vm.hostname = "localhost"
 
   # Oracle port forwarding
   config.vm.network "forwarded_port", guest: 1521, host: 1521

--- a/OracleAPEX/scripts/database.sh
+++ b/OracleAPEX/scripts/database.sh
@@ -21,10 +21,6 @@
 #    scoter     03/19/19 - Creation
 #
 
-# remove fake entry to hostname pointing to 127.0.0.1
-sed -i -e "/$HOSTNAME/d" /etc/hosts
-echo "10.0.2.15 $HOSTNAME" >> /etc/hosts
-
 # set environment variables
 echo "export ORACLE_BASE=/opt/oracle" >> /home/oracle/.bashrc && \
 echo "export ORACLE_HOME=/opt/oracle/product/18c/dbhomeXE" >> /home/oracle/.bashrc && \
@@ -77,9 +73,6 @@ echo 'XEPDB1 =
 ' >> /opt/oracle/product/18c/dbhomeXE/network/admin/tnsnames.ora
 
 echo 'INSTALLER: TNS entry added'
-
-#clean up temporary entry in /etc/hosts
-sed -i -e "s/10.0.2.15/127.0.0.1/" /etc/hosts
 
 # configure systemd to start oracle instance on startup
 systemctl daemon-reload


### PR DESCRIPTION
Adds support for libvirt/KVM to the OracleAPEX project.

- `Vagrantfile`: add libvirt configuration
- `Vagrantfile`: set VM hostname to "localhost"
- `database.sh`: remove code that temporarily modifies `/etc/hosts`
- `README.md`: updates for new functionality and new repo name
- `README.md`: resolve markdownlint warnings

Setting the VM hostname to "localhost" in the `Vagrantfile` and removing the code in `database.sh` that temporarily modifies `/etc/hosts` are required for listener configuration to succeed on libvirt. These changes are consistent with the OracleDatabase/18.4.0-XE project.

This has been tested on both VirtualBox and libvirt/KVM.

I'm happy to make any changes that you'd like.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>