### PR TITLE
Increase default VM memory for 18c and 19c boxes (#241)

### DIFF
--- a/OracleDatabase/18.3.0/.env
+++ b/OracleDatabase/18.3.0/.env
@@ -11,8 +11,8 @@
 # VM name
 # VM_NAME='oracle-18c-vagrant'
 
-# Memory for the VM (in MB, 2048 MB = 2 GB)
-# VM_MEMORY=2048
+# Memory for the VM (in MB, 2300 MB is ~2.25 GB)
+# VM_MEMORY=2300
 
 # VM time zone
 # If not specified, will be set to match host time zone (if possible)

--- a/OracleDatabase/18.3.0/README.md
+++ b/OracleDatabase/18.3.0/README.md
@@ -69,7 +69,7 @@ Parameters are considered in the following order (first one wins):
 ### VM parameters
 
 * `VM_NAME` (default: `oracle-18c-vagrant`): VM name.
-* `VM_MEMORY` (default: 2048): memory for the VM (in MB, 2048 MB = 2 GB).
+* `VM_MEMORY` (default: 2300): memory for the VM (in MB, 2300 MB is ~2.25 GB).
 * `VM_SYSTEM_TIMEZONE` (default: host time zone (if possible)): VM time zone.
   * The system time zone is used by the database for SYSDATE/SYSTIMESTAMP.
   * The guest time zone will be set to the host time zone when the host time zone is a full hour offset from GMT.

--- a/OracleDatabase/18.3.0/Vagrantfile
+++ b/OracleDatabase/18.3.0/Vagrantfile
@@ -35,8 +35,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # VM name
   VM_NAME = default_s('VM_NAME', 'oracle-18c-vagrant')
 
-  # Memory for the VM (in MB, 2048 MB = 2 GB)
-  VM_MEMORY = default_i('VM_MEMORY', 2048)
+  # Memory for the VM (in MB, 2300 MB is ~2.25 GB)
+  VM_MEMORY = default_i('VM_MEMORY', 2300)
 
   # VM time zone
   # If not specified, will be set to match host time zone (if possible)

--- a/OracleDatabase/19.3.0/.env
+++ b/OracleDatabase/19.3.0/.env
@@ -11,8 +11,8 @@
 # VM name
 # VM_NAME='oracle-19c-vagrant'
 
-# Memory for the VM (in MB, 2048 MB = 2 GB)
-# VM_MEMORY=2048
+# Memory for the VM (in MB, 2300 MB is ~2.25 GB)
+# VM_MEMORY=2300
 
 # VM time zone
 # If not specified, will be set to match host time zone (if possible)

--- a/OracleDatabase/19.3.0/README.md
+++ b/OracleDatabase/19.3.0/README.md
@@ -69,7 +69,7 @@ Parameters are considered in the following order (first one wins):
 ### VM parameters
 
 * `VM_NAME` (default: `oracle-19c-vagrant`): VM name.
-* `VM_MEMORY` (default: 2048): memory for the VM (in MB, 2048 MB = 2 GB).
+* `VM_MEMORY` (default: 2300): memory for the VM (in MB, 2300 MB is ~2.25 GB).
 * `VM_SYSTEM_TIMEZONE` (default: host time zone (if possible)): VM time zone.
   * The system time zone is used by the database for SYSDATE/SYSTIMESTAMP.
   * The guest time zone will be set to the host time zone when the host time zone is a full hour offset from GMT.

--- a/OracleDatabase/19.3.0/Vagrantfile
+++ b/OracleDatabase/19.3.0/Vagrantfile
@@ -35,8 +35,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # VM name
   VM_NAME = default_s('VM_NAME', 'oracle-19c-vagrant')
 
-  # Memory for the VM (in MB, 2048 MB = 2 GB)
-  VM_MEMORY = default_i('VM_MEMORY', 2048)
+  # Memory for the VM (in MB, 2300 MB is ~2.25 GB)
+  VM_MEMORY = default_i('VM_MEMORY', 2300)
 
   # VM time zone
   # If not specified, will be set to match host time zone (if possible)


### PR DESCRIPTION
Increase default VM memory from 2048 MB to 2300 MB for the OracleDatabase/18.3.0 and OracleDatabase/19.3.0 single-instance database projects to eliminate a memory warning from DBCA. Fixes #241.

The 19.3.0 changes have been tested on both VirtualBox and libvirt. The 18.3.0 changes have been tested on VirtualBox. (18.3.0 doesn't support libvirt yet, but I'm working on that.)

I'm happy to make any changes that you'd like.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>