### PR TITLE
Database projects - add libvirt support

### DIFF
--- a/OracleDatabase/11.2.0.2/README.md
+++ b/OracleDatabase/11.2.0.2/README.md
@@ -1,12 +1,11 @@
 # oracle11g-xe-vagrant
 
-A vagrant box that provisions Oracle Database automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
+This Vagrant project provisions Oracle Database automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
 
 ## Prerequisites
 
-1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-2. Install [Vagrant](https://vagrantup.com/)
-3. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
+1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
+2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
 makes configuration much easier
 
 ## Getting started

--- a/OracleDatabase/11.2.0.2/README.md
+++ b/OracleDatabase/11.2.0.2/README.md
@@ -11,14 +11,14 @@ makes configuration much easier
 ## Getting started
 
 1. Clone this repository `git clone https://github.com/oracle/vagrant-projects`
-2. Change into the `vagrant-projects/OracleDatabase/11.2.0.2` folder
-3. Download the installation zip file (`oracle-xe-11.2.0-1.0.x86_64.rpm.zip`) from OTN into this folder - first time only:
+2. Change into the `vagrant-projects/OracleDatabase/11.2.0.2` directory
+3. Download the installation zip file (`oracle-xe-11.2.0-1.0.x86_64.rpm.zip`) from OTN into this directory - first time only:
 [http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html](http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html)
 4. Run `vagrant up`
-   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the virtual box to the latest via `yum`.
+   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the VM to the latest via `yum`.
    2. The installation can be customized, if desired (see [Configuration](#configuration)).
 5. Connect to the database (see [Connecting to Oracle](#connecting-to-oracle))
-6. You can shut down the box via the usual `vagrant halt` and then start it up again via `vagrant up`
+6. You can shut down the VM via the usual `vagrant halt` and then start it up again via `vagrant up`
 
 ## Connecting to Oracle
 
@@ -52,7 +52,7 @@ The `Vagrantfile` can be used _as-is_, without any additional configuration. How
 There are three ways to set parameters:
 
 1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
-2. Use environment variables. It might be difficult to remember the parameters used when the box was instantiated.
+2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
 3. Use the `.env`/`.env.local` files (requires
 [vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
 
@@ -66,7 +66,7 @@ Parameters are considered in the following order (first one wins):
 ### VM parameters
 
 * `VM_NAME` (default: `oracle11g-xe-vagrant`): VM name.
-* `VM_MEMORY` (default: 2048): memory for the VM (in MB, 2048 MB = 2 GB).
+* `VM_MEMORY` (default: `2048`): memory for the VM (in MB, 2048 MB = 2 GB).
 * `VM_SYSTEM_TIMEZONE` (default: host time zone (if possible)): VM time zone.
   * The system time zone is used by the database for SYSDATE/SYSTIMESTAMP.
   * The guest time zone will be set to the host time zone when the host time zone is a full hour offset from GMT.

--- a/OracleDatabase/11.2.0.2/Vagrantfile
+++ b/OracleDatabase/11.2.0.2/Vagrantfile
@@ -77,10 +77,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "#{BOX_URL}/#{BOX_NAME}.json"
   config.vm.define VM_NAME
 
-  # Provider-specific configuration -- VirtualBox
+  # Provider-specific configuration
   config.vm.provider "virtualbox" do |v|
     v.memory = VM_MEMORY
     v.name = VM_NAME
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = VM_MEMORY
   end
 
   # add proxy configuration from host env - optional

--- a/OracleDatabase/12.1.0.2/README.md
+++ b/OracleDatabase/12.1.0.2/README.md
@@ -11,16 +11,16 @@ makes configuration much easier
 ## Getting started
 
 1. Clone this repository `git clone https://github.com/oracle/vagrant-projects`
-2. Change into the `vagrant-projects/OracleDatabase/12.1.0.2` folder
-3. Download the installation zip files from OTN into this folder - first time only:
+2. Change into the `vagrant-projects/OracleDatabase/12.1.0.2` directory
+3. Download the installation zip files from OTN into this directory - first time only:
 [http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html](http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html)
 
     The zip files for Enterprise Edition (EE) are `linuxamd64_12102_database_1of2.zip` and `linuxamd64_12102_database_2of2.zip`. The zip files for Standard Edition 2 (SE2) are `linuxamd64_12102_database_se2_1of2.zip` and `linuxamd64_12102_database_se2_2of2.zip`. Make sure to download the correct files for the edition you want to use.
 4. Run `vagrant up`
-   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the virtual box to the latest via `yum`.
+   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the VM to the latest via `yum`.
    2. The installation can be customized, if desired (see [Configuration](#configuration)).
 5. Connect to the database (see [Connecting to Oracle](#connecting-to-oracle))
-6. You can shut down the box via the usual `vagrant halt` and then start it up again via `vagrant up`
+6. You can shut down the VM via the usual `vagrant halt` and then start it up again via `vagrant up`
 
 ## Connecting to Oracle
 
@@ -56,7 +56,7 @@ The `Vagrantfile` can be used _as-is_, without any additional configuration. How
 There are three ways to set parameters:
 
 1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
-2. Use environment variables. It might be difficult to remember the parameters used when the box was instantiated.
+2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
 3. Use the `.env`/`.env.local` files (requires
 [vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
 
@@ -70,7 +70,7 @@ Parameters are considered in the following order (first one wins):
 ### VM parameters
 
 * `VM_NAME` (default: `oracle-12102-vagrant`): VM name.
-* `VM_MEMORY` (default: 2048): memory for the VM (in MB, 2048 MB = 2 GB).
+* `VM_MEMORY` (default: `2048`): memory for the VM (in MB, 2048 MB = 2 GB).
 * `VM_SYSTEM_TIMEZONE` (default: host time zone (if possible)): VM time zone.
   * The system time zone is used by the database for SYSDATE/SYSTIMESTAMP.
   * The guest time zone will be set to the host time zone when the host time zone is a full hour offset from GMT.

--- a/OracleDatabase/12.1.0.2/README.md
+++ b/OracleDatabase/12.1.0.2/README.md
@@ -1,12 +1,11 @@
 # oracle12cR1-vagrant
 
-A vagrant box that provisions Oracle Database automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
+This Vagrant project provisions Oracle Database automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
 
 ## Prerequisites
 
-1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-2. Install [Vagrant](https://vagrantup.com/)
-3. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
+1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
+2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
 makes configuration much easier
 
 ## Getting started

--- a/OracleDatabase/12.1.0.2/Vagrantfile
+++ b/OracleDatabase/12.1.0.2/Vagrantfile
@@ -99,10 +99,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "#{BOX_URL}/#{BOX_NAME}.json"
   config.vm.define VM_NAME
 
-  # Provider-specific configuration -- VirtualBox
+  # Provider-specific configuration
   config.vm.provider "virtualbox" do |v|
     v.memory = VM_MEMORY
     v.name = VM_NAME
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = VM_MEMORY
   end
 
   # add proxy configuration from host env - optional

--- a/OracleDatabase/12.2.0.1/README.md
+++ b/OracleDatabase/12.2.0.1/README.md
@@ -1,12 +1,11 @@
 # oracle12c-vagrant
 
-A vagrant box that provisions Oracle Database automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
+This Vagrant project provisions Oracle Database automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
 
 ## Prerequisites
 
-1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-2. Install [Vagrant](https://vagrantup.com/)
-3. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
+1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
+2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
 makes configuration much easier
 
 ## Getting started

--- a/OracleDatabase/12.2.0.1/README.md
+++ b/OracleDatabase/12.2.0.1/README.md
@@ -11,14 +11,14 @@ makes configuration much easier
 ## Getting started
 
 1. Clone this repository `git clone https://github.com/oracle/vagrant-projects`
-2. Change into the `vagrant-projects/OracleDatabase/12.2.0.1` folder
-3. Download the installation zip file (`linuxx64_12201_database.zip`) from OTN into this folder - first time only:
+2. Change into the `vagrant-projects/OracleDatabase/12.2.0.1` directory
+3. Download the installation zip file (`linuxx64_12201_database.zip`) from OTN into this directory - first time only:
 [http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html](http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html)
 4. Run `vagrant up`
-   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the virtual box to the latest via `yum`.
+   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the VM to the latest via `yum`.
    2. The installation can be customized, if desired (see [Configuration](#configuration)).
 5. Connect to the database (see [Connecting to Oracle](#connecting-to-oracle))
-6. You can shut down the box via the usual `vagrant halt` and then start it up again via `vagrant up`
+6. You can shut down the VM via the usual `vagrant halt` and then start it up again via `vagrant up`
 
 ## Connecting to Oracle
 
@@ -54,7 +54,7 @@ The `Vagrantfile` can be used _as-is_, without any additional configuration. How
 There are three ways to set parameters:
 
 1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
-2. Use environment variables. It might be difficult to remember the parameters used when the box was instantiated.
+2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
 3. Use the `.env`/`.env.local` files (requires
 [vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
 
@@ -68,7 +68,7 @@ Parameters are considered in the following order (first one wins):
 ### VM parameters
 
 * `VM_NAME` (default: `oracle-12201-vagrant`): VM name.
-* `VM_MEMORY` (default: 2048): memory for the VM (in MB, 2048 MB = 2 GB).
+* `VM_MEMORY` (default: `2048`): memory for the VM (in MB, 2048 MB = 2 GB).
 * `VM_SYSTEM_TIMEZONE` (default: host time zone (if possible)): VM time zone.
   * The system time zone is used by the database for SYSDATE/SYSTIMESTAMP.
   * The guest time zone will be set to the host time zone when the host time zone is a full hour offset from GMT.

--- a/OracleDatabase/12.2.0.1/Vagrantfile
+++ b/OracleDatabase/12.2.0.1/Vagrantfile
@@ -99,10 +99,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "#{BOX_URL}/#{BOX_NAME}.json"
   config.vm.define VM_NAME
 
-  # Provider-specific configuration -- VirtualBox
+  # Provider-specific configuration
   config.vm.provider "virtualbox" do |v|
     v.memory = VM_MEMORY
     v.name = VM_NAME
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = VM_MEMORY
   end
 
   # add proxy configuration from host env - optional

--- a/OracleDatabase/18.3.0/README.md
+++ b/OracleDatabase/18.3.0/README.md
@@ -11,14 +11,14 @@ makes configuration much easier
 ## Getting started
 
 1. Clone this repository `git clone https://github.com/oracle/vagrant-projects`
-2. Change into the `vagrant-projects/OracleDatabase/18.3.0` folder
-3. Download the installation zip file (`LINUX.X64_180000_db_home.zip`) from OTN into this folder - first time only:
+2. Change into the `vagrant-projects/OracleDatabase/18.3.0` directory
+3. Download the installation zip file (`LINUX.X64_180000_db_home.zip`) from OTN into this directory - first time only:
 [http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html](http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html)
 4. Run `vagrant up`
-   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the virtual box to the latest via `yum`.
+   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the VM to the latest via `yum`.
    2. The installation can be customized, if desired (see [Configuration](#configuration)).
 5. Connect to the database (see [Connecting to Oracle](#connecting-to-oracle))
-6. You can shut down the box via the usual `vagrant halt` and then start it up again via `vagrant up`
+6. You can shut down the VM via the usual `vagrant halt` and then start it up again via `vagrant up`
 
 ## Connecting to Oracle
 
@@ -54,7 +54,7 @@ The `Vagrantfile` can be used _as-is_, without any additional configuration. How
 There are three ways to set parameters:
 
 1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
-2. Use environment variables. It might be difficult to remember the parameters used when the box was instantiated.
+2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
 3. Use the `.env`/`.env.local` files (requires
 [vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
 
@@ -68,7 +68,7 @@ Parameters are considered in the following order (first one wins):
 ### VM parameters
 
 * `VM_NAME` (default: `oracle-18c-vagrant`): VM name.
-* `VM_MEMORY` (default: 2300): memory for the VM (in MB, 2300 MB is ~2.25 GB).
+* `VM_MEMORY` (default: `2300`): memory for the VM (in MB, 2300 MB is ~2.25 GB).
 * `VM_SYSTEM_TIMEZONE` (default: host time zone (if possible)): VM time zone.
   * The system time zone is used by the database for SYSDATE/SYSTIMESTAMP.
   * The guest time zone will be set to the host time zone when the host time zone is a full hour offset from GMT.

--- a/OracleDatabase/18.3.0/README.md
+++ b/OracleDatabase/18.3.0/README.md
@@ -1,12 +1,11 @@
 # oracle-18c-vagrant
 
-A vagrant box that provisions Oracle Database automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
+This Vagrant project provisions Oracle Database automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
 
 ## Prerequisites
 
-1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-2. Install [Vagrant](https://vagrantup.com/)
-3. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
+1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
+2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
 makes configuration much easier
 
 ## Getting started

--- a/OracleDatabase/18.3.0/Vagrantfile
+++ b/OracleDatabase/18.3.0/Vagrantfile
@@ -99,10 +99,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "#{BOX_URL}/#{BOX_NAME}.json"
   config.vm.define VM_NAME
 
-  # Provider-specific configuration -- VirtualBox
+  # Provider-specific configuration
   config.vm.provider "virtualbox" do |v|
     v.memory = VM_MEMORY
     v.name = VM_NAME
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = VM_MEMORY
   end
 
   # add proxy configuration from host env - optional

--- a/OracleDatabase/18.4.0-XE/README.md
+++ b/OracleDatabase/18.4.0-XE/README.md
@@ -11,12 +11,12 @@ makes configuration much easier
 ## Getting started
 
 1. Clone this repository `git clone https://github.com/oracle/vagrant-projects`
-2. Change into the `vagrant-projects/OracleDatabase/18.4.0-XE` folder
+2. Change into the `vagrant-projects/OracleDatabase/18.4.0-XE` directory
 3. Run `vagrant up`
-   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the virtual box to the latest via `yum`.
+   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the VM to the latest via `yum`.
    2. The installation can be customized, if desired (see [Configuration](#configuration)).
 4. Connect to the database (see [Connecting to Oracle](#connecting-to-oracle))
-5. You can shut down the box via the usual `vagrant halt` and then start it up again via `vagrant up`
+5. You can shut down the VM via the usual `vagrant halt` and then start it up again via `vagrant up`
 
 ## Connecting to Oracle
 
@@ -52,7 +52,7 @@ The `Vagrantfile` can be used _as-is_, without any additional configuration. How
 There are three ways to set parameters:
 
 1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
-2. Use environment variables. It might be difficult to remember the parameters used when the box was instantiated.
+2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
 3. Use the `.env`/`.env.local` files (requires
 [vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
 
@@ -66,7 +66,7 @@ Parameters are considered in the following order (first one wins):
 ### VM parameters
 
 * `VM_NAME` (default: `oracle18c-xe-vagrant`): VM name.
-* `VM_MEMORY` (default: 2048): memory for the VM (in MB, 2048 MB = 2 GB).
+* `VM_MEMORY` (default: `2048`): memory for the VM (in MB, 2048 MB = 2 GB).
 * `VM_SYSTEM_TIMEZONE` (default: host time zone (if possible)): VM time zone.
   * The system time zone is used by the database for SYSDATE/SYSTIMESTAMP.
   * The guest time zone will be set to the host time zone when the host time zone is a full hour offset from GMT.

--- a/OracleDatabase/18.4.0-XE/README.md
+++ b/OracleDatabase/18.4.0-XE/README.md
@@ -1,12 +1,11 @@
 # oracle18c-xe-vagrant
 
-A vagrant box that provisions Oracle Database automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
+This Vagrant project provisions Oracle Database automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
 
 ## Prerequisites
 
-1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-2. Install [Vagrant](https://vagrantup.com/)
-3. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
+1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
+2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
 makes configuration much easier
 
 ## Getting started

--- a/OracleDatabase/18.4.0-XE/Vagrantfile
+++ b/OracleDatabase/18.4.0-XE/Vagrantfile
@@ -83,10 +83,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "#{BOX_URL}/#{BOX_NAME}.json"
   config.vm.define VM_NAME
 
-  # Provider-specific configuration -- VirtualBox
+  # Provider-specific configuration
   config.vm.provider "virtualbox" do |v|
     v.memory = VM_MEMORY
     v.name = VM_NAME
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = VM_MEMORY
   end
 
   # add proxy configuration from host env - optional

--- a/OracleDatabase/19.3.0/README.md
+++ b/OracleDatabase/19.3.0/README.md
@@ -11,14 +11,14 @@ makes configuration much easier
 ## Getting started
 
 1. Clone this repository `git clone https://github.com/oracle/vagrant-projects`
-2. Change into the `vagrant-projects/OracleDatabase/19.3.0` folder
-3. Download the installation zip file (`LINUX.X64_193000_db_home.zip`) from OTN into this folder - first time only:
+2. Change into the `vagrant-projects/OracleDatabase/19.3.0` directory
+3. Download the installation zip file (`LINUX.X64_193000_db_home.zip`) from OTN into this directory - first time only:
 [http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html](http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html)
 4. Run `vagrant up`
-   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the virtual box to the latest via `yum`.
+   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the VM to the latest via `yum`.
    2. The installation can be customized, if desired (see [Configuration](#configuration)).
 5. Connect to the database (see [Connecting to Oracle](#connecting-to-oracle))
-6. You can shut down the box via the usual `vagrant halt` and then start it up again via `vagrant up`
+6. You can shut down the VM via the usual `vagrant halt` and then start it up again via `vagrant up`
 
 ## Connecting to Oracle
 
@@ -54,7 +54,7 @@ The `Vagrantfile` can be used _as-is_, without any additional configuration. How
 There are three ways to set parameters:
 
 1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
-2. Use environment variables. It might be difficult to remember the parameters used when the box was instantiated.
+2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
 3. Use the `.env`/`.env.local` files (requires
 [vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
 
@@ -68,7 +68,7 @@ Parameters are considered in the following order (first one wins):
 ### VM parameters
 
 * `VM_NAME` (default: `oracle-19c-vagrant`): VM name.
-* `VM_MEMORY` (default: 2300): memory for the VM (in MB, 2300 MB is ~2.25 GB).
+* `VM_MEMORY` (default: `2300`): memory for the VM (in MB, 2300 MB is ~2.25 GB).
 * `VM_SYSTEM_TIMEZONE` (default: host time zone (if possible)): VM time zone.
   * The system time zone is used by the database for SYSDATE/SYSTIMESTAMP.
   * The guest time zone will be set to the host time zone when the host time zone is a full hour offset from GMT.

--- a/OracleDatabase/19.3.0/README.md
+++ b/OracleDatabase/19.3.0/README.md
@@ -1,12 +1,11 @@
 # oracle-19c-vagrant
 
-A vagrant box that provisions Oracle Database automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
+This Vagrant project provisions Oracle Database automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
 
 ## Prerequisites
 
-1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-2. Install [Vagrant](https://vagrantup.com/)
-3. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
+1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
+2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
 makes configuration much easier
 
 ## Getting started

--- a/OracleDatabase/19.3.0/Vagrantfile
+++ b/OracleDatabase/19.3.0/Vagrantfile
@@ -99,7 +99,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "#{BOX_URL}/#{BOX_NAME}.json"
   config.vm.define VM_NAME
 
-  # Provider-specific configuration -- VirtualBox
+  # Provider-specific configuration
   config.vm.provider "virtualbox" do |v|
     v.memory = VM_MEMORY
     v.name = VM_NAME

--- a/OracleDatabase/README.md
+++ b/OracleDatabase/README.md
@@ -1,12 +1,14 @@
-# Oracle Database Vagrant boxes
+# Oracle Database Vagrant projects
+
 This directory contains Vagrant build files to provision an Oracle Database automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
 
 ## Prerequisites
-1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)
-2. Install [Vagrant](https://vagrantup.com/)
+
+Read the [prerequisites in the top level README](../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
 
 ## Getting started
-1. Clone this repository `git clone https://github.com/oracle/vagrant-boxes`
+
+1. Clone this repository `git clone https://github.com/oracle/vagrant-projects`
 2. Change into the desired version folder
 3. Download the installation zip files from OTN into this folder - first time only:
 [http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html](http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html)
@@ -17,7 +19,8 @@ This directory contains Vagrant build files to provision an Oracle Database auto
 **For more information please check the individual README within each folder!**
 
 ## Acknowledgements
-Based on:
-@steveswinsburg's work here: https://github.com/steveswinsburg/oracle12c-vagrant  
-@totalamateurhour's work here: https://github.com/totalamateurhour/oracle-12.2-vagrant  
-@gvenzl's work here: https://github.com/gvenzl/vagrant-boxes
+
+Based on:  
+@steveswinsburg's work here: [https://github.com/steveswinsburg/oracle12c-vagrant](https://github.com/steveswinsburg/oracle12c-vagrant)  
+@totalamateurhour's work here: [https://github.com/totalamateurhour/oracle-12.2-vagrant](https://github.com/totalamateurhour/oracle-12.2-vagrant)  
+@gvenzl's work here: [https://github.com/gvenzl/vagrant-boxes](https://github.com/gvenzl/vagrant-boxes)

--- a/OracleDatabase/README.md
+++ b/OracleDatabase/README.md
@@ -9,14 +9,14 @@ Read the [prerequisites in the top level README](../README.md#prerequisites) to 
 ## Getting started
 
 1. Clone this repository `git clone https://github.com/oracle/vagrant-projects`
-2. Change into the desired version folder
-3. Download the installation zip files from OTN into this folder - first time only:
+2. Change into the desired version directory
+3. Download the installation zip file(s) from OTN into this directory - first time only:
 [http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html](http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html)
 4. Run `vagrant up`
 5. Connect to the database.
-6. You can shut down the box via the usual `vagrant halt` and the start it up again via `vagrant up`.
+6. You can shut down the VM via the usual `vagrant halt` and the start it up again via `vagrant up`.
 
-**For more information please check the individual README within each folder!**
+**For more information please check the individual README within each directory!**
 
 ## Acknowledgements
 


### PR DESCRIPTION
Adds support for libvirt/KVM to the single-instance database projects.

- `Vagrantfile`s: add libvirt configuration (except for 19.3.0, which already had it)
- `README.md` files: updates for new functionality
- `OracleDatabase/README.md`: updates for new functionality and repo name; resolve markdownlint warnings

These changes have been tested on both VirtualBox and libvirt/KVM.

I'm happy to make any changes that you'd like.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>