### PR TITLE
Database projects - Don't install plugins

### DIFF
--- a/OracleDatabase/11.2.0.2/README.md
+++ b/OracleDatabase/11.2.0.2/README.md
@@ -78,6 +78,22 @@ Parameters are considered in the following order (first one wins):
 * `VM_LISTENER_PORT` (default: `1521`): Listener port.
 * `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS and SYSTEM accounts.
 
+## Optional plugins
+
+When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+
+* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
+variables from .env files;
+* [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
+proxies in the guest VM if you need to access the Internet through a proxy. See
+the plugin documentation for configuration.
+
+To install Vagrant plugins run:
+
+```shell
+vagrant plugin install <name>...
+```
+
 ## Other info
 
 * If you need to, you can connect to the virtual machine via `vagrant ssh`.

--- a/OracleDatabase/11.2.0.2/Vagrantfile
+++ b/OracleDatabase/11.2.0.2/Vagrantfile
@@ -6,6 +6,10 @@
 # Since: January, 2018
 # Author: gerald.venzl@oracle.com
 # Description: Creates an Oracle database Vagrant virtual machine.
+# Optional plugins:
+#     vagrant-env (use .env files for configuration)
+#     vagrant-proxyconf (if you don't have direct access to the Internet)
+#         see https://github.com/tmatilai/vagrant-proxyconf for configuration
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
@@ -20,10 +24,8 @@ VAGRANTFILE_API_VERSION = "2"
 BOX_URL = "https://oracle.github.io/vagrant-projects/boxes"
 BOX_NAME = "oraclelinux/7"
 
-unless Vagrant.has_plugin?("vagrant-proxyconf")
-  puts 'Installing vagrant-proxyconf Plugin...'
-  system('vagrant plugin install vagrant-proxyconf')
-end
+# UI object for printing information
+ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
 
 # Define constants
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -88,17 +90,45 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # add proxy configuration from host env - optional
   if Vagrant.has_plugin?("vagrant-proxyconf")
-    puts "getting Proxy Configuration from Host..."
-    if ENV["http_proxy"]
-      puts "http_proxy: " + ENV["http_proxy"]
-      config.proxy.http     = ENV["http_proxy"]
+    ui.info "Getting Proxy Configuration from Host..."
+    has_proxy = false
+    ["http_proxy", "HTTP_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTP proxy: " + proxy
+        config.proxy.http = proxy
+        has_proxy = true
+        break
+      end
     end
-    if ENV["https_proxy"]
-      puts "https_proxy: " + ENV["https_proxy"]
-      config.proxy.https    = ENV["https_proxy"]
+
+    ["https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTPS proxy: " + proxy
+        config.proxy.https = proxy
+        has_proxy = true
+        break
+      end
     end
-    if ENV["no_proxy"]
-      config.proxy.no_proxy = ENV["no_proxy"]
+
+    if has_proxy
+      # Only consider no_proxy if we have proxies defined.
+      no_proxy = ""
+      ["no_proxy", "NO_PROXY"].each do |proxy_var|
+        if ENV[proxy_var]
+          no_proxy = ENV[proxy_var]
+          ui.info "No proxy: " + no_proxy
+          no_proxy += ","
+          break
+        end
+      end
+      config.proxy.no_proxy = no_proxy + "localhost,127.0.0.1"
+    end
+  else
+    ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if ENV[proxy_var]
+        ui.warn 'To enable proxies in your VM, install the vagrant-proxyconf plugin'
+        break
+      end
     end
   end
 

--- a/OracleDatabase/12.1.0.2/README.md
+++ b/OracleDatabase/12.1.0.2/README.md
@@ -89,6 +89,22 @@ Parameters are considered in the following order (first one wins):
 * `VM_EM_EXPRESS_PORT` (default: `5500`): EM Express port.
 * `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS, SYSTEM and PDBADMIN accounts.
 
+## Optional plugins
+
+When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+
+* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
+variables from .env files;
+* [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
+proxies in the guest VM if you need to access the Internet through a proxy. See
+the plugin documentation for configuration.
+
+To install Vagrant plugins run:
+
+```shell
+vagrant plugin install <name>...
+```
+
 ## Other info
 
 * If you need to, you can connect to the virtual machine via `vagrant ssh`.

--- a/OracleDatabase/12.1.0.2/Vagrantfile
+++ b/OracleDatabase/12.1.0.2/Vagrantfile
@@ -6,6 +6,10 @@
 # Since: January, 2018
 # Author: gerald.venzl@oracle.com
 # Description: Creates an Oracle database Vagrant virtual machine.
+# Optional plugins:
+#     vagrant-env (use .env files for configuration)
+#     vagrant-proxyconf (if you don't have direct access to the Internet)
+#         see https://github.com/tmatilai/vagrant-proxyconf for configuration
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
@@ -20,10 +24,8 @@ VAGRANTFILE_API_VERSION = "2"
 BOX_URL = "https://oracle.github.io/vagrant-projects/boxes"
 BOX_NAME = "oraclelinux/7"
 
-unless Vagrant.has_plugin?("vagrant-proxyconf")
-  puts 'Installing vagrant-proxyconf Plugin...'
-  system('vagrant plugin install vagrant-proxyconf')
-end
+# UI object for printing information
+ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
 
 # Define constants
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -110,17 +112,45 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # add proxy configuration from host env - optional
   if Vagrant.has_plugin?("vagrant-proxyconf")
-    puts "getting Proxy Configuration from Host..."
-    if ENV["http_proxy"]
-      puts "http_proxy: " + ENV["http_proxy"]
-      config.proxy.http     = ENV["http_proxy"]
+    ui.info "Getting Proxy Configuration from Host..."
+    has_proxy = false
+    ["http_proxy", "HTTP_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTP proxy: " + proxy
+        config.proxy.http = proxy
+        has_proxy = true
+        break
+      end
     end
-    if ENV["https_proxy"]
-      puts "https_proxy: " + ENV["https_proxy"]
-      config.proxy.https    = ENV["https_proxy"]
+
+    ["https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTPS proxy: " + proxy
+        config.proxy.https = proxy
+        has_proxy = true
+        break
+      end
     end
-    if ENV["no_proxy"]
-      config.proxy.no_proxy = ENV["no_proxy"]
+
+    if has_proxy
+      # Only consider no_proxy if we have proxies defined.
+      no_proxy = ""
+      ["no_proxy", "NO_PROXY"].each do |proxy_var|
+        if ENV[proxy_var]
+          no_proxy = ENV[proxy_var]
+          ui.info "No proxy: " + no_proxy
+          no_proxy += ","
+          break
+        end
+      end
+      config.proxy.no_proxy = no_proxy + "localhost,127.0.0.1"
+    end
+  else
+    ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if ENV[proxy_var]
+        ui.warn 'To enable proxies in your VM, install the vagrant-proxyconf plugin'
+        break
+      end
     end
   end
 

--- a/OracleDatabase/12.2.0.1/README.md
+++ b/OracleDatabase/12.2.0.1/README.md
@@ -87,6 +87,22 @@ Parameters are considered in the following order (first one wins):
 * `VM_EM_EXPRESS_PORT` (default: `5500`): EM Express port.
 * `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS, SYSTEM and PDBADMIN accounts.
 
+## Optional plugins
+
+When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+
+* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
+variables from .env files;
+* [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
+proxies in the guest VM if you need to access the Internet through a proxy. See
+the plugin documentation for configuration.
+
+To install Vagrant plugins run:
+
+```shell
+vagrant plugin install <name>...
+```
+
 ## Other info
 
 * If you need to, you can connect to the virtual machine via `vagrant ssh`.

--- a/OracleDatabase/12.2.0.1/Vagrantfile
+++ b/OracleDatabase/12.2.0.1/Vagrantfile
@@ -6,6 +6,10 @@
 # Since: January, 2018
 # Author: gerald.venzl@oracle.com
 # Description: Creates an Oracle database Vagrant virtual machine.
+# Optional plugins:
+#     vagrant-env (use .env files for configuration)
+#     vagrant-proxyconf (if you don't have direct access to the Internet)
+#         see https://github.com/tmatilai/vagrant-proxyconf for configuration
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
@@ -20,10 +24,8 @@ VAGRANTFILE_API_VERSION = "2"
 BOX_URL = "https://oracle.github.io/vagrant-projects/boxes"
 BOX_NAME = "oraclelinux/7"
 
-unless Vagrant.has_plugin?("vagrant-proxyconf")
-  puts 'Installing vagrant-proxyconf Plugin...'
-  system('vagrant plugin install vagrant-proxyconf')
-end
+# UI object for printing information
+ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
 
 # Define constants
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -110,17 +112,45 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # add proxy configuration from host env - optional
   if Vagrant.has_plugin?("vagrant-proxyconf")
-    puts "getting Proxy Configuration from Host..."
-    if ENV["http_proxy"]
-      puts "http_proxy: " + ENV["http_proxy"]
-      config.proxy.http     = ENV["http_proxy"]
+    ui.info "Getting Proxy Configuration from Host..."
+    has_proxy = false
+    ["http_proxy", "HTTP_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTP proxy: " + proxy
+        config.proxy.http = proxy
+        has_proxy = true
+        break
+      end
     end
-    if ENV["https_proxy"]
-      puts "https_proxy: " + ENV["https_proxy"]
-      config.proxy.https    = ENV["https_proxy"]
+
+    ["https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTPS proxy: " + proxy
+        config.proxy.https = proxy
+        has_proxy = true
+        break
+      end
     end
-    if ENV["no_proxy"]
-      config.proxy.no_proxy = ENV["no_proxy"]
+
+    if has_proxy
+      # Only consider no_proxy if we have proxies defined.
+      no_proxy = ""
+      ["no_proxy", "NO_PROXY"].each do |proxy_var|
+        if ENV[proxy_var]
+          no_proxy = ENV[proxy_var]
+          ui.info "No proxy: " + no_proxy
+          no_proxy += ","
+          break
+        end
+      end
+      config.proxy.no_proxy = no_proxy + "localhost,127.0.0.1"
+    end
+  else
+    ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if ENV[proxy_var]
+        ui.warn 'To enable proxies in your VM, install the vagrant-proxyconf plugin'
+        break
+      end
     end
   end
 

--- a/OracleDatabase/18.3.0/README.md
+++ b/OracleDatabase/18.3.0/README.md
@@ -87,6 +87,22 @@ Parameters are considered in the following order (first one wins):
 * `VM_EM_EXPRESS_PORT` (default: `5500`): EM Express port.
 * `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS, SYSTEM and PDBADMIN accounts.
 
+## Optional plugins
+
+When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+
+* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
+variables from .env files;
+* [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
+proxies in the guest VM if you need to access the Internet through a proxy. See
+the plugin documentation for configuration.
+
+To install Vagrant plugins run:
+
+```shell
+vagrant plugin install <name>...
+```
+
 ## Other info
 
 * If you need to, you can connect to the virtual machine via `vagrant ssh`.

--- a/OracleDatabase/18.3.0/Vagrantfile
+++ b/OracleDatabase/18.3.0/Vagrantfile
@@ -6,6 +6,10 @@
 # Since: July, 2018
 # Author: gerald.venzl@oracle.com
 # Description: Creates an Oracle database Vagrant virtual machine.
+# Optional plugins:
+#     vagrant-env (use .env files for configuration)
+#     vagrant-proxyconf (if you don't have direct access to the Internet)
+#         see https://github.com/tmatilai/vagrant-proxyconf for configuration
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
@@ -20,10 +24,8 @@ VAGRANTFILE_API_VERSION = "2"
 BOX_URL = "https://oracle.github.io/vagrant-projects/boxes"
 BOX_NAME = "oraclelinux/7"
 
-unless Vagrant.has_plugin?("vagrant-proxyconf")
-  puts 'Installing vagrant-proxyconf Plugin...'
-  system('vagrant plugin install vagrant-proxyconf')
-end
+# UI object for printing information
+ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
 
 # Define constants
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -110,17 +112,45 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # add proxy configuration from host env - optional
   if Vagrant.has_plugin?("vagrant-proxyconf")
-    puts "getting Proxy Configuration from Host..."
-    if ENV["http_proxy"]
-      puts "http_proxy: " + ENV["http_proxy"]
-      config.proxy.http     = ENV["http_proxy"]
+    ui.info "Getting Proxy Configuration from Host..."
+    has_proxy = false
+    ["http_proxy", "HTTP_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTP proxy: " + proxy
+        config.proxy.http = proxy
+        has_proxy = true
+        break
+      end
     end
-    if ENV["https_proxy"]
-      puts "https_proxy: " + ENV["https_proxy"]
-      config.proxy.https    = ENV["https_proxy"]
+
+    ["https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTPS proxy: " + proxy
+        config.proxy.https = proxy
+        has_proxy = true
+        break
+      end
     end
-    if ENV["no_proxy"]
-      config.proxy.no_proxy = ENV["no_proxy"]
+
+    if has_proxy
+      # Only consider no_proxy if we have proxies defined.
+      no_proxy = ""
+      ["no_proxy", "NO_PROXY"].each do |proxy_var|
+        if ENV[proxy_var]
+          no_proxy = ENV[proxy_var]
+          ui.info "No proxy: " + no_proxy
+          no_proxy += ","
+          break
+        end
+      end
+      config.proxy.no_proxy = no_proxy + "localhost,127.0.0.1"
+    end
+  else
+    ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if ENV[proxy_var]
+        ui.warn 'To enable proxies in your VM, install the vagrant-proxyconf plugin'
+        break
+      end
     end
   end
 

--- a/OracleDatabase/18.4.0-XE/README.md
+++ b/OracleDatabase/18.4.0-XE/README.md
@@ -80,6 +80,22 @@ Parameters are considered in the following order (first one wins):
 * `VM_EM_EXPRESS_PORT` (default: `5500`): EM Express port.
 * `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS, SYSTEM and PDBADMIN accounts.
 
+## Optional plugins
+
+When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+
+* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
+variables from .env files;
+* [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
+proxies in the guest VM if you need to access the Internet through a proxy. See
+the plugin documentation for configuration.
+
+To install Vagrant plugins run:
+
+```shell
+vagrant plugin install <name>...
+```
+
 ## Other info
 
 * If you need to, you can connect to the virtual machine via `vagrant ssh`.

--- a/OracleDatabase/18.4.0-XE/Vagrantfile
+++ b/OracleDatabase/18.4.0-XE/Vagrantfile
@@ -6,6 +6,10 @@
 # Since: July, 2018
 # Author: gerald.venzl@oracle.com
 # Description: Creates an Oracle database Vagrant virtual machine.
+# Optional plugins:
+#     vagrant-env (use .env files for configuration)
+#     vagrant-proxyconf (if you don't have direct access to the Internet)
+#         see https://github.com/tmatilai/vagrant-proxyconf for configuration
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
@@ -20,10 +24,8 @@ VAGRANTFILE_API_VERSION = "2"
 BOX_URL = "https://oracle.github.io/vagrant-projects/boxes"
 BOX_NAME = "oraclelinux/7"
 
-unless Vagrant.has_plugin?("vagrant-proxyconf")
-  puts 'Installing vagrant-proxyconf Plugin...'
-  system('vagrant plugin install vagrant-proxyconf')
-end
+# UI object for printing information
+ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
 
 # Define constants
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -94,17 +96,45 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # add proxy configuration from host env - optional
   if Vagrant.has_plugin?("vagrant-proxyconf")
-    puts "getting Proxy Configuration from Host..."
-    if ENV["http_proxy"]
-      puts "http_proxy: " + ENV["http_proxy"]
-      config.proxy.http     = ENV["http_proxy"]
+    ui.info "Getting Proxy Configuration from Host..."
+    has_proxy = false
+    ["http_proxy", "HTTP_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTP proxy: " + proxy
+        config.proxy.http = proxy
+        has_proxy = true
+        break
+      end
     end
-    if ENV["https_proxy"]
-      puts "https_proxy: " + ENV["https_proxy"]
-      config.proxy.https    = ENV["https_proxy"]
+
+    ["https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTPS proxy: " + proxy
+        config.proxy.https = proxy
+        has_proxy = true
+        break
+      end
     end
-    if ENV["no_proxy"]
-      config.proxy.no_proxy = ENV["no_proxy"]
+
+    if has_proxy
+      # Only consider no_proxy if we have proxies defined.
+      no_proxy = ""
+      ["no_proxy", "NO_PROXY"].each do |proxy_var|
+        if ENV[proxy_var]
+          no_proxy = ENV[proxy_var]
+          ui.info "No proxy: " + no_proxy
+          no_proxy += ","
+          break
+        end
+      end
+      config.proxy.no_proxy = no_proxy + "localhost,127.0.0.1"
+    end
+  else
+    ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if ENV[proxy_var]
+        ui.warn 'To enable proxies in your VM, install the vagrant-proxyconf plugin'
+        break
+      end
     end
   end
 

--- a/OracleDatabase/19.3.0/README.md
+++ b/OracleDatabase/19.3.0/README.md
@@ -87,6 +87,22 @@ Parameters are considered in the following order (first one wins):
 * `VM_EM_EXPRESS_PORT` (default: `5500`): EM Express port.
 * `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS, SYSTEM and PDBADMIN accounts.
 
+## Optional plugins
+
+When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+
+* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
+variables from .env files;
+* [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
+proxies in the guest VM if you need to access the Internet through a proxy. See
+the plugin documentation for configuration.
+
+To install Vagrant plugins run:
+
+```shell
+vagrant plugin install <name>...
+```
+
 ## Other info
 
 * If you need to, you can connect to the virtual machine via `vagrant ssh`.

--- a/OracleDatabase/19.3.0/Vagrantfile
+++ b/OracleDatabase/19.3.0/Vagrantfile
@@ -6,6 +6,10 @@
 # Since: July, 2018
 # Author: gerald.venzl@oracle.com
 # Description: Creates an Oracle database Vagrant virtual machine.
+# Optional plugins:
+#     vagrant-env (use .env files for configuration)
+#     vagrant-proxyconf (if you don't have direct access to the Internet)
+#         see https://github.com/tmatilai/vagrant-proxyconf for configuration
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
@@ -20,10 +24,8 @@ VAGRANTFILE_API_VERSION = "2"
 BOX_URL = "https://oracle.github.io/vagrant-projects/boxes"
 BOX_NAME = "oraclelinux/7"
 
-unless Vagrant.has_plugin?("vagrant-proxyconf")
-  puts 'Installing vagrant-proxyconf Plugin...'
-  system('vagrant plugin install vagrant-proxyconf')
-end
+# UI object for printing information
+ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
 
 # Define constants
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -110,17 +112,45 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # add proxy configuration from host env - optional
   if Vagrant.has_plugin?("vagrant-proxyconf")
-    puts "getting Proxy Configuration from Host..."
-    if ENV["http_proxy"]
-      puts "http_proxy: " + ENV["http_proxy"]
-      config.proxy.http     = ENV["http_proxy"]
+    ui.info "Getting Proxy Configuration from Host..."
+    has_proxy = false
+    ["http_proxy", "HTTP_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTP proxy: " + proxy
+        config.proxy.http = proxy
+        has_proxy = true
+        break
+      end
     end
-    if ENV["https_proxy"]
-      puts "https_proxy: " + ENV["https_proxy"]
-      config.proxy.https    = ENV["https_proxy"]
+
+    ["https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTPS proxy: " + proxy
+        config.proxy.https = proxy
+        has_proxy = true
+        break
+      end
     end
-    if ENV["no_proxy"]
-      config.proxy.no_proxy = ENV["no_proxy"]
+
+    if has_proxy
+      # Only consider no_proxy if we have proxies defined.
+      no_proxy = ""
+      ["no_proxy", "NO_PROXY"].each do |proxy_var|
+        if ENV[proxy_var]
+          no_proxy = ENV[proxy_var]
+          ui.info "No proxy: " + no_proxy
+          no_proxy += ","
+          break
+        end
+      end
+      config.proxy.no_proxy = no_proxy + "localhost,127.0.0.1"
+    end
+  else
+    ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if ENV[proxy_var]
+        ui.warn 'To enable proxies in your VM, install the vagrant-proxyconf plugin'
+        break
+      end
     end
   end
 


### PR DESCRIPTION
Don't install plugins in the `Vagrantfile`s for the single-instance database projects. Changes for each project are:

`Vagrantfile`:
- Removed code that installs the vagrant-proxyconf plugin
- Updated proxy configuration code to the latest version developed by @AmedeeBulle (see #265). This handles both upper- and lower-case proxy environment variables and doesn't set `no_proxy` unless a proxy has been defined.

`README.md`:
- Added "Optional plugins" section consistent with other projects in this repo

This has been tested on both VirtualBox and libvirt/KVM.

I'm happy to make any changes that you'd like.

(I still owe you a PR with these changes for the APEX project. I didn't include the APEX project here to avoid any conflicts with #271.)

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>