### PR TITLE
APEX project - Fix tnsnames entry for PDB

### DIFF
--- a/OracleAPEX/scripts/database.sh
+++ b/OracleAPEX/scripts/database.sh
@@ -64,7 +64,7 @@ chmod o+r /opt/oracle/product/18c/dbhomeXE/network/admin/tnsnames.ora
 # add tnsnames.ora entry for PDB
 echo 'XEPDB1 =
   (DESCRIPTION =
-    (ADDRESS = (PROTOCOL = TCP)(HOST = oracle-18c-apex)(PORT = 1521))
+    (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = 1521))
     (CONNECT_DATA =
       (SERVER = DEDICATED)
       (SERVICE_NAME = XEPDB1)


### PR DESCRIPTION
Change hostname from "oracle-18c-apex" to "localhost" in the section of `database.sh` that creates the tnsnames.ora entry for the PDB. This is consistent with `OracleDatabase/18.4.0-XE/scripts/install.sh`. Fixes #274.

To validate:
- Build the project
- `vagrant ssh`
- Run `. oraenv`, using "XE" for the ORACLE_SID
- Verify that `sqlplus pdbadmin/\"<password>\"@XEPDB1` successfully connects

Again, I apologize for missing this.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>