### PR TITLE
APEX project - Don't install plugins

### DIFF
--- a/OracleAPEX/README.md
+++ b/OracleAPEX/README.md
@@ -12,7 +12,7 @@ Read the [prerequisites in the top level README](../README.md#prerequisites) to 
 1. Change into the `vagrant-projects/OracleAPEX` directory
 1. Download the Oracle Database XE 18.4 installation rpm file from OTN into this directory - first time only:
 [https://www.oracle.com/technetwork/database/database-technologies/express-edition/downloads/index.html](https://www.oracle.com/technetwork/database/database-technologies/express-edition/downloads/index.html)
-1. Download the Oracle APEX into this directory - first time only:
+1. Download Oracle APEX into this directory - first time only:
 [https://www.oracle.com/tools/downloads/apex-downloads.html](https://www.oracle.com/tools/downloads/apex-downloads.html)
 1. Download Oracle Rest Data Services (ORDS) into this directory - first time only:
 [https://www.oracle.com/database/technologies/appdev/rest-data-services-downloads.html](https://www.oracle.com/database/technologies/appdev/rest-data-services-downloads.html)
@@ -62,3 +62,17 @@ Oracle Application Express Access will be available on the host OS by accessing 
 * `Password: <See auto-generated password>`
 
 At the first login you'll be forced to change the default `admin` password.
+
+## Optional plugins
+
+When installed, this Vagrant project will make use of the following third party Vagrant plugin:
+
+* [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
+proxies in the guest VM if you need to access the Internet through a proxy. See
+the plugin documentation for configuration.
+
+To install Vagrant plugins run:
+
+```shell
+vagrant plugin install <name>...
+```

--- a/OracleAPEX/Vagrantfile
+++ b/OracleAPEX/Vagrantfile
@@ -62,15 +62,8 @@ BOX_NAME = "oraclelinux/7"
 # define hostname
 NAME = "oracle-18c-apex"
 
-unless Vagrant.has_plugin?("vagrant-reload")
-  puts 'Installing vagrant-reload Plugin...'
-  system('vagrant plugin install vagrant-reload')
-end
-
-unless Vagrant.has_plugin?("vagrant-proxyconf")
-  puts 'Installing vagrant-proxyconf Plugin...'
-  system('vagrant plugin install vagrant-proxyconf')
-end
+# UI object for printing information
+ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
 
 # get host time zone for setting VM time zone, if possible
 # can override in env section below
@@ -89,7 +82,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "#{BOX_URL}/#{BOX_NAME}.json"
   config.vm.define NAME
 
-  # change memory size
+  # Provider-specific configuration
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048
     v.name = NAME
@@ -100,17 +93,45 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # add proxy configuration from host env - optional
   if Vagrant.has_plugin?("vagrant-proxyconf")
-    puts "getting Proxy Configuration from Host..."
-    if ENV["http_proxy"]
-      puts "http_proxy: " + ENV["http_proxy"]
-      config.proxy.http     = ENV["http_proxy"]
+    ui.info "Getting Proxy Configuration from Host..."
+    has_proxy = false
+    ["http_proxy", "HTTP_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTP proxy: " + proxy
+        config.proxy.http = proxy
+        has_proxy = true
+        break
+      end
     end
-    if ENV["https_proxy"]
-      puts "https_proxy: " + ENV["https_proxy"]
-      config.proxy.https    = ENV["https_proxy"]
+
+    ["https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTPS proxy: " + proxy
+        config.proxy.https = proxy
+        has_proxy = true
+        break
+      end
     end
-    if ENV["no_proxy"]
-      config.proxy.no_proxy = ENV["no_proxy"]
+
+    if has_proxy
+      # Only consider no_proxy if we have proxies defined.
+      no_proxy = ""
+      ["no_proxy", "NO_PROXY"].each do |proxy_var|
+        if ENV[proxy_var]
+          no_proxy = ENV[proxy_var]
+          ui.info "No proxy: " + no_proxy
+          no_proxy += ","
+          break
+        end
+      end
+      config.proxy.no_proxy = no_proxy + "localhost,127.0.0.1"
+    end
+  else
+    ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if ENV[proxy_var]
+        ui.warn 'To enable proxies in your VM, install the vagrant-proxyconf plugin'
+        break
+      end
     end
   end
 


### PR DESCRIPTION
Don't install plugins in the `Vagrantfile` for the APEX project. Changes are:

`Vagrantfile`:
- Removed code that installs the vagrant-reload and vagrant-proxyconf plugins. (The vagrant-reload plugin wasn't actually used.)
- Updated proxy configuration code to the latest version developed by @AmedeeBulle (see #265). This handles both upper- and lower-case proxy environment variables and doesn't set `no_proxy` unless a proxy has been defined.
- Updated comment for provider-specific configuration.

`README.md`:
- Fixed typo.
- Added "Optional plugins" section consistent with other projects in this repo.

This has been tested on both VirtualBox and libvirt/KVM.

I'm happy to make any changes that you'd like.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>