### PR TITLE
APEX project - Support ORDS 20.2 (#281)

### DIFF
--- a/OracleAPEX/scripts/ords.sh
+++ b/OracleAPEX/scripts/ords.sh
@@ -31,7 +31,13 @@ mkdir $ORACLE_BASE/ords
 export ORDS_HOME=$ORACLE_BASE/ords
 echo "export ORDS_HOME=$ORACLE_BASE/ords" >> /home/oracle/.bashrc
 cd  $ORDS_HOME
-ORDS_INSTALL=`ls /vagrant/ords[_-]1*.*.zip |tail -1`
+ORDS_INSTALL=$(find /vagrant -maxdepth 1 -name "ords[_-]*.*.zip" -type f | tail -1)
+
+if [[ -z ${ORDS_INSTALL} || ! -r "${ORDS_INSTALL}" ]]; then
+  echo 'INSTALLER: Could not find ORDS installer file. Exiting.'
+  exit 1
+fi
+
 unzip $ORDS_INSTALL
 chown -R oracle:oinstall $ORDS_HOME
 


### PR DESCRIPTION
Fixes #281 by updating the `ords.sh` script to support the ORDS 20.2 installer, as well as earlier/later versions. Also eliminates two ShellCheck warnings.

To validate, verify that the project builds and runs correctly with the ORDS 20.2 installer, and that the `ords.sh` script exits if the ORDS installer is not present.

I'm happy to make any changes that you'd like.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>