### PR TITLE
18.4.0-XE - Add save installer option

### DIFF
--- a/OracleDatabase/18.4.0-XE/.env
+++ b/OracleDatabase/18.4.0-XE/.env
@@ -20,6 +20,9 @@
 # or an offset from GMT (e.g., 'Etc/GMT-2')
 # VM_SYSTEM_TIMEZONE=
 
+# Save database installer RPM file for reuse when VM is rebuilt
+# VM_KEEP_DB_INSTALLER=false
+
 # Database character set
 # VM_ORACLE_CHARACTERSET='AL32UTF8'
 

--- a/OracleDatabase/18.4.0-XE/README.md
+++ b/OracleDatabase/18.4.0-XE/README.md
@@ -75,6 +75,7 @@ Parameters are considered in the following order (first one wins):
 
 ### Oracle Database parameters
 
+* `VM_KEEP_DB_INSTALLER` (default: `false`): save database installer RPM file for reuse when VM is rebuilt.
 * `VM_ORACLE_CHARACTERSET` (default: `AL32UTF8`): database character set.
 * `VM_LISTENER_PORT` (default: `1521`): Listener port.
 * `VM_EM_EXPRESS_PORT` (default: `5500`): EM Express port.

--- a/OracleDatabase/18.4.0-XE/Vagrantfile
+++ b/OracleDatabase/18.4.0-XE/Vagrantfile
@@ -44,6 +44,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # If not specified, will be set to match host time zone (if possible)
   VM_SYSTEM_TIMEZONE = default_s('VM_SYSTEM_TIMEZONE', host_tz)
 
+  # Save database installer RPM file for reuse when VM is rebuilt
+  VM_KEEP_DB_INSTALLER = default_b('VM_KEEP_DB_INSTALLER', false)
+
   # Database character set
   VM_ORACLE_CHARACTERSET = default_s('VM_ORACLE_CHARACTERSET', 'AL32UTF8')
 
@@ -65,6 +68,10 @@ end
 
 def default_i(key, default)
   default_s(key, default).to_i
+end
+
+def default_b(key, default)
+  default_s(key, default).to_s.downcase == "true"
 end
 
 def host_tz
@@ -150,6 +157,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "shell", path: "scripts/install.sh", env:
     {
        "SYSTEM_TIMEZONE"     => VM_SYSTEM_TIMEZONE,
+       "KEEP_DB_INSTALLER"   => VM_KEEP_DB_INSTALLER,
        "ORACLE_CHARACTERSET" => VM_ORACLE_CHARACTERSET,
        "LISTENER_PORT"       => VM_LISTENER_PORT,
        "EM_EXPRESS_PORT"     => VM_EM_EXPRESS_PORT,

--- a/OracleDatabase/18.4.0-XE/scripts/install.sh
+++ b/OracleDatabase/18.4.0-XE/scripts/install.sh
@@ -19,9 +19,6 @@ echo 'INSTALLER: Started up'
 # get up to date
 yum upgrade -y
 
-# ensure wget is installed for downloading database installer
-yum install -y wget
-
 echo 'INSTALLER: System updated'
 
 # fix locale warning
@@ -55,8 +52,10 @@ echo 'INSTALLER: Environment variables set'
 db_installer='oracle-database-xe-18c-1.0-1.x86_64.rpm'
 if [[ ! -f /vagrant/"${db_installer}" ]]; then
   echo 'INSTALLER: Downloading Oracle Database software'
-  wget -q -P /vagrant \
-    https://download.oracle.com/otn-pub/otn_software/db-express/"${db_installer}"
+  (
+    cd /vagrant || exit 1
+    curl -L -O -s https://download.oracle.com/otn-pub/otn_software/db-express/"${db_installer}"
+  )
 fi
 
 yum -y localinstall /vagrant/"${db_installer}"

--- a/OracleDatabase/18.4.0-XE/scripts/install.sh
+++ b/OracleDatabase/18.4.0-XE/scripts/install.sh
@@ -19,6 +19,9 @@ echo 'INSTALLER: Started up'
 # get up to date
 yum upgrade -y
 
+# ensure wget is installed for downloading database installer
+yum install -y wget
+
 echo 'INSTALLER: System updated'
 
 # fix locale warning
@@ -48,7 +51,19 @@ echo "export PATH=\$PATH:\$ORACLE_HOME/bin" >> /home/oracle/.bashrc
 echo 'INSTALLER: Environment variables set'
 
 # Install Oracle
-yum -y localinstall https://download.oracle.com/otn-pub/otn_software/db-express/oracle-database-xe-18c-1.0-1.x86_64.rpm
+# if installer doesn't exist, download it
+db_installer='oracle-database-xe-18c-1.0-1.x86_64.rpm'
+if [[ ! -f /vagrant/"${db_installer}" ]]; then
+  echo 'INSTALLER: Downloading Oracle Database software'
+  wget -q -P /vagrant \
+    https://download.oracle.com/otn-pub/otn_software/db-express/"${db_installer}"
+fi
+
+yum -y localinstall /vagrant/"${db_installer}"
+
+if [[ "${KEEP_DB_INSTALLER,,}" == 'false' ]]; then
+  rm -f /vagrant/"${db_installer}"
+fi
 
 echo 'INSTALLER: Oracle software installed'
 


### PR DESCRIPTION
Add an option to the OracleDatabase/18.4.0-XE project to save the database installer file. Changes are:

`.env`
- Add a Boolean configuration parameter called "VM_KEEP_DB_INSTALLER" (default false).

`README.md`
- Document the "VM_KEEP_DB_INSTALLER" parameter in the Configuration section.

`Vagrantfile`
- Add code to evaluate the "VM_KEEP_DB_INSTALLER" parameter and pass it to `install.sh`.

`scripts/install.sh`
- Ensure wget is installed (it's already installed in the current oraclelinux/7 box, but just in case).
- Download the database installer file to `/vagrant`, if it's not already present.
- Install the database software from `/vagrant`, instead of directly from OTN.
- Delete the database installer file if the "KEEP_DB_INSTALLER" environment variable is false.

Closes #279.

To validate:
- Verify that the database installer RPM file is downloaded to `/vagrant` during the build, if it's not already present.
- Verify that the database installer RPM file is deleted if the "VM_KEEP_DB_INSTALLER" parameter is false.
- Verify that the database installer RPM file is kept if the "VM_KEEP_DB_INSTALLER" parameter is true.

I'm happy to make any changes that you'd like.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>