### PR TITLE
Use Vagrant "disks" feature to add extra disk.

### DIFF
--- a/DockerEngine/Vagrantfile
+++ b/DockerEngine/Vagrantfile
@@ -16,6 +16,10 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+# Required for the Disks feature
+Vagrant.require_version ">= 2.2.8"
+ENV['VAGRANT_EXPERIMENTAL'] = 'disks'
+
 # Box metadata location and box name
 BOX_URL = "https://oracle.github.io/vagrant-projects/boxes"
 BOX_NAME = "oraclelinux/7"
@@ -67,9 +71,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   # change memory size
-  config.vm.provider "virtualbox" do |v|
+  config.vm.provider "virtualbox" do |v, override|
     v.memory = 2048
     v.name = NAME
+    override.vm.disk :disk, size: '16GB', name: 'docker_storage'
   end
   config.vm.provider :libvirt do |v|
     v.memory = 2048

--- a/Kubernetes/Vagrantfile
+++ b/Kubernetes/Vagrantfile
@@ -40,6 +40,10 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+# Required for the Disks feature
+Vagrant.require_version ">= 2.2.8"
+ENV['VAGRANT_EXPERIMENTAL'] = 'disks'
+
 # Box metadata location and box name
 BOX_URL = "https://oracle.github.io/vagrant-projects/boxes"
 BOX_NAME = "oraclelinux/7"
@@ -170,6 +174,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # - Manager
   config.vm.define "master", primary: true do |master|
     master.vm.hostname = "master.vagrant.vm"
+    master.vm.disk :disk, size: '16GB', name: 'k8s_master'
     master.vm.network "private_network", ip: "192.168.99.100"
     if Vagrant.has_plugin?("vagrant-hosts")
       master.vm.provision :hosts, :sync_hosts => true
@@ -211,6 +216,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   (1..NB_WORKERS).each do |i|
     config.vm.define "worker#{i}" do |worker|
       worker.vm.hostname = "worker#{i}.vagrant.vm"
+      worker.vm.disk :disk, size: '16GB', name: "k8s_worker#{i}"
       ip = 100 + i
       worker.vm.network "private_network", ip: "192.168.99.#{ip}"
       if Vagrant.has_plugin?("vagrant-hosts")


### PR DESCRIPTION
As we plan to drop the extra disk from the VirtualBox boxes (see #278), add disk creation for the projects using it.

The Vagrant _disks_ feature is still experimental, but works well for our use case. This has been tested by stripping the extra disk from our latest VirtualBox boxes.

Tagged as WIP for review and until we ship new boxes without the extra disk.

Only for the virtualbox provider (libvirt already have such feature).
Note that disk names must be unique due to hashicorp/vagrant#11755.

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>