### PR TITLE
OLCNE: pull NGINX image pro-actively on master nodes

### DIFF
--- a/OLCNE/Vagrantfile
+++ b/OLCNE/Vagrantfile
@@ -238,12 +238,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         master.vm.network "forwarded_port", guest: 8001, host: 8001
       end
       # Provisioning: install stuff
-      args = ["--master", "--ip-addr", ip_addr]
+      args = ["--master", "--ip-addr", ip_addr, "--nginx-image", NGINX_IMAGE]
       if !STANDALONE_OPERATOR && i == 1
         args.push("--operator")
         args.push("--workers", workers.chop)
         args.push("--masters", masters.chop)
-        args.push("--nginx-image", NGINX_IMAGE)
       end
       provision_vm(master.vm, args)
     end

--- a/OLCNE/scripts/provision.sh
+++ b/OLCNE/scripts/provision.sh
@@ -323,6 +323,7 @@ requirements() {
 # the vagrant environment.
 # Globals:
 #   OPERATOR OLCNE_VERSION MASTER WORKER K8S_VERSION MULTI_MASTER
+#   REGISTRY_OLCNE NGINX_IMAGE
 # Arguments:
 #   None
 # Returns:
@@ -390,6 +391,9 @@ install_packages() {
     # Software load balancer firewall rules
     echo_do firewall-cmd --add-port=6444/tcp --permanent
     echo_do firewall-cmd --add-protocol=vrrp --permanent
+
+    # Pull NGINX image to avoid proxy issue during module installation
+    echo_do podman pull "${REGISTRY_OLCNE}/${NGINX_IMAGE}"
   fi
 
   # Restart firewalld


### PR DESCRIPTION
NGINX image is not pulled when proxies are used.
This PR pulls the image beforehand to make it available to OLCNE agent.

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>