### PR TITLE
Issue 295: setPassword.sh fails for PDBADMIN

### DIFF
--- a/OracleDatabase/18.4.0-XE/scripts/setPassword.sh
+++ b/OracleDatabase/18.4.0-XE/scripts/setPassword.sh
@@ -12,7 +12,7 @@
 
 ORACLE_PWD=$1
 ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
-ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v pdbseed | awk '{print $9}' | cut -d/ -f6`"
+ORACLE_PDB="XEPDB1"
 ORAENV_ASK=NO
 source oraenv
 


### PR DESCRIPTION
Signed-off-by: Göran Paues <goran.paues@tradedoubler.com>

Fix for issue 295. I suggest fixing the issue by hard coding the name XEPDB1 instead of trying to find the PDB name, as the name is not configurable anyway.