### PR TITLE
perform unzip quietly for oracle zip file

### DIFF
--- a/OracleDatabase/19.3.0/scripts/install.sh
+++ b/OracleDatabase/19.3.0/scripts/install.sh
@@ -54,7 +54,7 @@ echo 'INSTALLER: Environment variables set'
 
 # Install Oracle
 
-unzip /vagrant/LINUX.X64_193000_db_home.zip -d $ORACLE_HOME/
+unzip -qq /vagrant/LINUX.X64_193000_db_home.zip -d $ORACLE_HOME/
 cp /vagrant/ora-response/db_install.rsp.tmpl /vagrant/ora-response/db_install.rsp
 sed -i -e "s|###ORACLE_BASE###|$ORACLE_BASE|g" /vagrant/ora-response/db_install.rsp
 sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" /vagrant/ora-response/db_install.rsp


### PR DESCRIPTION
Hi,

don't output in terminal  message of extracted file like

for LINUX.X64_193000_db_home.zip

inflating: 
  inflating: 
  inflating: 
  inflating: 

also it speed up time of extraction: 
Time to extract (in my case)

1) with -qq: 66 seconds
2) with -q: 85 seconds
3) without: 106 seconds



thanks