### PR TITLE
ISSUE-308: Fix inconsistency in variable definitions in setup.sh

### DIFF
--- a/OracleDG/scripts/setup.sh
+++ b/OracleDG/scripts/setup.sh
@@ -94,7 +94,7 @@ export NODE1_PUBLIC_IP=$NODE1_PUBLIC_IP
 export NODE2_PUBLIC_IP=$NODE2_PUBLIC_IP
 #----------------------------------------------------------
 #----------------------------------------------------------
-export DOMAIN_NAME=${DOMAIN_NAME}
+export DOMAIN_NAME=${DOMAIN}
 
 export NODE1_HOSTNAME=${VM1_NAME}
 export NODE2_HOSTNAME=${VM2_NAME}

--- a/OracleFPP/scripts/setup.sh
+++ b/OracleFPP/scripts/setup.sh
@@ -266,7 +266,7 @@ export HA_VIP=$HA_VIP
 export NODE2_PUBLIC_IP=$NODE2_PUBLIC_IP
 #----------------------------------------------------------
 #----------------------------------------------------------
-export DOMAIN_NAME=$DOMAIN
+export DOMAIN_NAME=${DOMAIN}
 
 export NODE1_HOSTNAME=${VM1_NAME}
 export NODE1_FQ_HOSTNAME=\${NODE1_HOSTNAME}.\${DOMAIN_NAME}

--- a/OracleRAC/scripts/setup.sh
+++ b/OracleRAC/scripts/setup.sh
@@ -501,7 +501,7 @@ export SCAN_IP2=$SCAN_IP2
 export SCAN_IP3=$SCAN_IP3
 #----------------------------------------------------------
 #----------------------------------------------------------
-export DOMAIN_NAME=localdomain
+export DOMAIN_NAME=${DOMAIN}
 
 export NODE1_HOSTNAME=${VM1_NAME}
 export NODE2_HOSTNAME=${VM2_NAME}


### PR DESCRIPTION
**Reference:**
Issue: https://github.com/oracle/vagrant-projects/issues/308

**Fix Details:**
Change environment variable export commands for variable `DOMAIN_NAME` in **setup.sh** for consistency and to fix bug with DG creations.

**Variable Use Validation:**
- To verify issue prior to fix being implemented: `grep -r DOMAIN * |grep -v NAME`  <--- Shows that variable passed into **setup.sh** is just named **DOMAIN**
- To verify variable refence in setup.sh: `grep -r "export\ DOMAIN" *`  <--- Shows that variable is used inconsistently prior to fix

**Test Details:**
- Tested fixed **setup.sh** with new VirtualBox based DG environment creation.