### PR TITLE
OLCNE: use box with UEK5

### DIFF
--- a/OLCNE/Vagrantfile
+++ b/OLCNE/Vagrantfile
@@ -204,6 +204,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     lv.nested = true
   end
 
+  # OLCNE is not certified yet against UEK6
+  config.vm.box_version = "< 7.9"
+
   # Workers provisioning
   workers = ""
   (1..NB_WORKERS).each do |i|


### PR DESCRIPTION
Latest boxes are based on OL7 Update 9 which come with UEK6 kernel.
As OLCNE is not certified yet against UEK6 this PR ensures the project uses the latest box with UEK5.

--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>