### PR TITLE
Remove restriction on OL7 box version 

### DIFF
--- a/OLCNE/Vagrantfile
+++ b/OLCNE/Vagrantfile
@@ -204,9 +204,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     lv.nested = true
   end
 
-  # OLCNE is not certified yet against UEK6
-  config.vm.box_version = "< 7.9"
-
   # Workers provisioning
   workers = ""
   (1..NB_WORKERS).each do |i|


### PR DESCRIPTION
OLCNE 1.1.7 supports UEK6, so the restriction is no longer required.

Signed-off-by: Avi Miller <avi.miller@oracle.com>