### PR TITLE
Correct link in OLCNE README.md

### DIFF
--- a/OLCNE/README.md
+++ b/OLCNE/README.md
@@ -182,4 +182,4 @@ Please provide feedback of any kind via GitHub issues on this repository.
 
 ## Contributing
 
-See [CONTRIBUTING](./CONTRIBUTING.md) for details.
+See [CONTRIBUTING](../CONTRIBUTING.md) for details.


### PR DESCRIPTION
Correct link to `CONTRIBUTING.md` in OLCNE `README.md` file. Fixes #329.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>