### PR TITLE
ASMFD support added

### DIFF
--- a/OracleRAC/Vagrantfile
+++ b/OracleRAC/Vagrantfile
@@ -113,6 +113,7 @@ var_asm_storage     = params['shared']['storage_pool_name']
 var_asm_disk_num    = params['shared']['asm_disk_num']
 var_asm_disk_size   = params['shared']['asm_disk_size']
 var_p1_ratio        = params['shared']['p1_ratio']
+var_asm_lib_type    = params['shared']['asm_lib_type']
 #
 var_gi_software     = params['env']['gi_software']
 var_gi_software_ver = (var_gi_software.split("_"))[1].to_i
@@ -136,7 +137,6 @@ var_pdb_name        = params['env']['pdb_name']
 var_db_type         = params['env']['db_type']
 var_cdb             = params['env']['cdb']
 
-var_asm_lib_type    = 'ASMLIB'
 
 # -----------------------------------------------------------------
 # Provider specific checks
@@ -387,11 +387,11 @@ end
 # VMs definition
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = var_box
-  config.vm.box_url = var_url
+  #config.vm.box_url = var_url
 
-  if var_provider_name == 'virtualbox'
-    config.vm.box_version = ">= 7.8.142"
-  end
+  #if var_provider_name == 'virtualbox'
+  #  config.vm.box_version = ">= 7.8.142"
+  #end
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -594,6 +594,20 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
     end
   end
+
+  # If var_asmlib_type is 'ASMFD', then the running kernel must be UEK4, otherwise ASMFD is not supported due to Grid Infrastructure being version 19.3
+  # It is worth noting that some GI RU later than 19.3 makes UEK5 supported as well, but not UEK6.
+   if var_asm_lib_type == 'ASMFD'
+     config.vm.provision :shell do |shell|
+       shell.privileged = true
+       shell.inline = <<-SHELL
+       echo "Installing UEK4 kernel (via yum)"
+       sed -i '/enabled=0/c\\enabled=1' /etc/yum.repos.d/uek-ol7.repo; yum install -y kernel-uek-4.1.12 kernel-uek-devel-4.1.12
+       echo "Rebooting to make UEK4 the running kernel, a prerequisite for ASMFD"
+       SHELL
+       shell.reboot = true
+     end
+   end
 
   # Enable ssh password authentication
   config.vm.provision "shell", inline: <<-SHELL

--- a/OracleRAC/config/vagrant.yml
+++ b/OracleRAC/config/vagrant.yml
@@ -31,6 +31,7 @@ shared:
   asm_disk_path:
   asm_disk_num:   4
   asm_disk_size: 20
+  asm_lib_type:  'ASMLIB'
   p1_ratio:      80
   # ---------------------------------------------
 

--- a/OracleRAC/scripts/05_setup_shared_disks.sh
+++ b/OracleRAC/scripts/05_setup_shared_disks.sh
@@ -60,9 +60,9 @@ LETTER=`tr 0123456789 abcdefghij <<< $BOX_DISK_NUM`
 SDISKSNUM=$(ls -l /dev/${DEVICE}[${LETTER}-z]|wc -l)
 for (( i=1; i<=$SDISKSNUM; i++ ))
 do
-  echo "KERNEL==\"/dev/${DEVICE}${LETTER}\",  SUBSYSTEM==\"block\", SYMLINK+=\"ORCL_DISK${i}\"    OWNER:=\"grid\", GROUP:=\"asmadmin\", MODE:=\"660\"" >> /etc/udev/rules.d/70-persistent-disk.rules
-  echo "KERNEL==\"/dev/${DEVICE}${LETTER}1\", SUBSYSTEM==\"block\", SYMLINK+=\"ORCL_DISK${i}_p1\" OWNER:=\"grid\", GROUP:=\"asmadmin\", MODE:=\"660\"" >> /etc/udev/rules.d/70-persistent-disk.rules
-  echo "KERNEL==\"/dev/${DEVICE}${LETTER}2\", SUBSYSTEM==\"block\", SYMLINK+=\"ORCL_DISK${i}_p2\" OWNER:=\"grid\", GROUP:=\"asmadmin\", MODE:=\"660\"" >> /etc/udev/rules.d/70-persistent-disk.rules
+  echo "KERNEL==\"sd?\",  ENV{ID_SERIAL}==\"`udevadm info --query=all --name=/dev/${DEVICE}${LETTER} | grep ID_SERIAL= | awk -F "=" '{print $2}'`\", SYMLINK+=\"ORCL_DISK${i}\", OWNER=\"grid\", GROUP=\"asmadmin\", MODE=\"0660\"" >> /etc/udev/rules.d/70-persistent-disk.rules
+  echo "KERNEL==\"sd?1\", ENV{ID_SERIAL}==\"`udevadm info --query=all --name=/dev/${DEVICE}${LETTER} | grep ID_SERIAL= | awk -F "=" '{print $2}'`\", SYMLINK+=\"ORCL_DISK${i}_p1\", OWNER=\"grid\", GROUP=\"asmadmin\", MODE=\"0660\"" >> /etc/udev/rules.d/70-persistent-disk.rules
+  echo "KERNEL==\"sd?2\", ENV{ID_SERIAL}==\"`udevadm info --query=all --name=/dev/${DEVICE}${LETTER} | grep ID_SERIAL= | awk -F "=" '{print $2}'`\", SYMLINK+=\"ORCL_DISK${i}_p2\", OWNER=\"grid\", GROUP=\"asmadmin\", MODE=\"0660\"" >> /etc/udev/rules.d/70-persistent-disk.rules
   LETTER=$(echo "$LETTER" | tr "0-9a-z" "1-9a-z_")
 done
 

--- a/OracleRAC/scripts/12_Make_ASMFD_RECODG.sh
+++ b/OracleRAC/scripts/12_Make_ASMFD_RECODG.sh
@@ -35,14 +35,13 @@ else
   export ORACLE_SID=+ASM
 fi
 
-DISKS_STRING=""
-declare -a DEVICES
-for device in /dev/ORCL_DISK*_p2
-do
-  DEVICES=("${dev[@]}" "$device")
-  DISK=$(basename "$DEVICES")
-  DISKS_STRING=${DISKS_STRING}"DISK '"${DEVICES}"' NAME "${DISK}" "
-done
+  DISKS_STRING="DISK "
+  for device in `(cd /dev/oracleafd/disks; ls ORCL_DISK*_P2)`
+  do
+    AFDDISK="AFD:${device}"
+    DISKS_STRING=${DISKS_STRING}"'$AFDDISK',"
+  done
+    DISKS_STRING="${DISKS_STRING::-1}"
 
 ${GI_HOME}/bin/sqlplus / as sysasm <<EOF
 CREATE DISKGROUP RECO NORMAL REDUNDANCY 

--- a/OracleRAC/scripts/setup.sh
+++ b/OracleRAC/scripts/setup.sh
@@ -140,7 +140,7 @@ DISKS=`echo $DISKS|tr -d ' '`
 cat >> /vagrant/scripts/09_gi_installation.sh <<EOF
     oracle.install.asm.diskGroup.disksWithFailureGroupNames=${DISKSFG} \\
     oracle.install.asm.diskGroup.disks=${DISKS} \\
-    oracle.install.asm.diskGroup.diskDiscoveryString=/dev/ORCL_* \\
+    oracle.install.asm.diskGroup.diskDiscoveryString=/dev/ORCL_*,AFD:* \\
     oracle.install.asm.configureAFD=true \\
 EOF
 else
@@ -249,7 +249,7 @@ DISKS=`echo $DISKS|tr -d ' '`
 cat >> /vagrant/scripts/11_gi_config.sh <<EOF
     oracle.install.asm.diskGroup.disksWithFailureGroupNames=${DISKSFG} \\
     oracle.install.asm.diskGroup.disks=${DISKS} \\
-    oracle.install.asm.diskGroup.diskDiscoveryString=/dev/ORCL_* \\
+    oracle.install.asm.diskGroup.diskDiscoveryString=/dev/ORCL_*,AFD:* \\
     oracle.install.asm.configureAFD=true \\
 EOF
 else


### PR DESCRIPTION
asm_lib_type moved to vagrant.yml

If var_asm_lib_type == 'ASMFD' then an extra provision is run to make sure the running kernel is UEK4.

UDEV rules changed so that the symlinks are added to /dev/ 

The RECO diskgroup script for ASMFD also changed, as the syntax was incorrect

Tested for this configuration
asm_lib_type='ASMFD'
db_type=SI
orestart=TRUE