### PR TITLE
Metadata for updated Vagrant Boxes

### DIFF
--- a/boxes/oraclelinux/6.json
+++ b/boxes/oraclelinux/6.json
@@ -2,7 +2,38 @@
   "description": "Oracle Linux 6",
   "short_description": "Oracle Linux 6",
   "name": "oraclelinux/6",
-  "versions": [{
+  "versions": [
+    {
+      "version": "6.10.193",
+      "status": "active",
+      "release_date": "08-Feb-2021",
+      "description_html": "<ul>\n<li>Packages refresh</li>\n</ul>\n",
+      "description_markdown": "* Packages refresh",
+      "providers": [{
+        "name": "virtualbox",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol6/OL6U10_x86_64-vagrant-virtualbox-b193.box",
+        "checksum": "3bee477a723bb0e4d7f2f0afa0a66ebfc7cba4272c427ba220075d895e65d6d8",
+        "checksum_type": "sha256",
+        "size": 368241023,
+        "kernel": "4.1.12-124.47.3.el6uek.x86_64"
+      }]
+    },
+    {
+      "version": "6.10.196",
+      "status": "active",
+      "release_date": "08-Feb-2021",
+      "description_html": "<ul>\n<li>Packages refresh</li>\n</ul>\n",
+      "description_markdown": "* Packages refresh",
+      "providers": [{
+        "name": "libvirt",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol6/OL6U10_x86_64-vagrant-libvirt-b196.box",
+        "checksum": "49261ac3b551f68834d1cc5ac9dabf9d4bb787467f283aaabff982dc6c1aff17",
+        "checksum_type": "sha256",
+        "size": 342903916,
+        "kernel": "4.1.12-124.47.3.el6uek.x86_64"
+      }]
+    },
+    {
       "version": "6.10.132",
       "status": "active",
       "release_date": "12-May-2020",

--- a/boxes/oraclelinux/7.json
+++ b/boxes/oraclelinux/7.json
@@ -4,6 +4,36 @@
   "name": "oraclelinux/7",
   "versions": [
     {
+      "version": "7.9.194",
+      "status": "active",
+      "release_date": "08-Feb-2021",
+      "description_html": "<ul>\n<li>Packages refresh</li>\n</ul>\n",
+      "description_markdown": "* Packages refresh",
+      "providers": [{
+        "name": "virtualbox",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol7/OL7U9_x86_64-vagrant-virtualbox-b194.box",
+        "checksum": "efbd00685f2a24c4fc00a869e0b86e8dec04549c6aafca327d183e4f832127ea",
+        "checksum_type": "sha256",
+        "size": 575163178,
+        "kernel": "5.4.17-2036.102.0.2.el7uek.x86_64"
+      }]
+    },
+    {
+      "version": "7.9.197",
+      "status": "active",
+      "release_date": "08-Feb-2021",
+      "description_html": "<ul>\n<li>Packages refresh</li>\n</ul>\n",
+      "description_markdown": "* Packages refresh",
+      "providers": [{
+        "name": "libvirt",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol7/OL7U9_x86_64-vagrant-libvirt-b197.box",
+        "checksum": "53c8c6b3803fd333e1002b370be484f02d4ac5096cc7c3e48417e14c94357742",
+        "checksum_type": "sha256",
+        "size": 546892812,
+        "kernel": "5.4.17-2036.102.0.2.el7uek.x86_64"
+      }]
+    },
+    {
       "version": "7.9.184",
       "status": "active",
       "release_date": "14-Nov-2020",

--- a/boxes/oraclelinux/8.json
+++ b/boxes/oraclelinux/8.json
@@ -4,6 +4,36 @@
   "name": "oraclelinux/8",
   "versions": [
     {
+      "version": "8.3.195",
+      "status": "active",
+      "release_date": "08-Feb-2021",
+      "description_html": "<ul>\n<li>Packages refresh</li>\n</ul>\n",
+      "description_markdown": "* Packages refresh",
+      "providers": [{
+        "name": "virtualbox",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol8/OL8U3_x86_64-vagrant-virtualbox-b195.box",
+        "checksum": "5421108670eec1967634f87462bb948b85ce65e3a104442c75ab1e827518d5a8",
+        "checksum_type": "sha256",
+        "size": 646091851,
+        "kernel": "5.4.17-2036.102.0.2.el8uek.x86_64"
+      }]
+    },
+    {
+      "version": "8.3.198",
+      "status": "active",
+      "release_date": "08-Feb-2021",
+      "description_html": "<ul>\n<li>Packages refresh</li>\n</ul>\n",
+      "description_markdown": "* Packages refresh",
+      "providers": [{
+        "name": "libvirt",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol8/OL8U3_x86_64-vagrant-libvirt-b198.box",
+        "checksum": "371b68209e4815e9bb7c0000e8f95f61317b057e7e58c9f71f140dcb82457b46",
+        "checksum_type": "sha256",
+        "size": 589613396,
+        "kernel": "5.4.17-2036.102.0.2.el8uek.x86_64"
+      }]
+    },
+    {
       "version": "8.3.182",
       "status": "active",
       "release_date": "14-Nov-2020",


### PR DESCRIPTION
Republish images, covering following advisories:

OL6:
- ELSA-2019-1652 libssh2 security update
- ELSA-2019-1726 dbus security update
- ELSA-2019-1774 vim security update
- ELSA-2019-2471 openssl security update
- ELSA-2019-4152 nss-softokn security update
- ELSA-2019-4877 python security update
- ELSA-2020-4182 kernel security and bug fix update
- ELSA-2020-5561 curl security update
- ELSA-2021-9019 sudo security update

OL7:
- ELSA-2020-5566-1 openssl security update
- ELSA-2021-0221 sudo security update
- ELSA-2021-0336 kernel security, bug fix, and enhancement update
- ELSA-2021-0348 glibc security and bug fix update
- ELSA-2021-9006 Unbreakable Enterprise kernel security update

OL8:
- ELSA-2020-5476 openssl security and bug fix update
- ELSA-2020-5483 gnutls security and bug fix update
- ELSA-2021-0003 kernel security and bug fix update
- ELSA-2021-0218 sudo security update
- ELSA-2021-9006 Unbreakable Enterprise kernel security update

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>