### PR TITLE
OLCNE deployment fixes

### DIFF
--- a/OLCNE/scripts/provision.sh
+++ b/OLCNE/scripts/provision.sh
@@ -14,7 +14,7 @@
 
 # Constants
 readonly CERT_DIR=/etc/olcne/pki
-readonly EXTERNALIP_VALIDATION_CERT_DIR=/etc/olcne/pki/externalip-validation-webhook
+readonly EXTERNALIP_VALIDATION_CERT_DIR=/etc/olcne/pki-externalip-validation-webhook
 
 #######################################
 # Convenience function used to limit output during provisioning
@@ -394,12 +394,6 @@ certificates() {
   echo_do bash -e ${CERT_DIR}/olcne-tranfer-certs.sh
 
   echo_do /etc/olcne/gen-certs-helper.sh --one-cert --nodes "externalip-validation-webhook-service.externalip-validation-system.svc,externalip-validation-webhook-service.externalip-validation-system.svc.cluster.local" --cert-dir "${EXTERNALIP_VALIDATION_CERT_DIR}"
-
-  echo_do sed -i -e "'s/externalip-validation-webhook-service.externalip-validation-system.svc externalip-validation-webhook-service.externalip-validation-system.svc.cluster.local/${nodes//,/ }/'" ${EXTERNALIP_VALIDATION_CERT_DIR}/olcne-tranfer-certs.sh
-
-  echo_do sed -i -e "'s/^USER=.*/USER=vagrant/'" ${EXTERNALIP_VALIDATION_CERT_DIR}/olcne-tranfer-certs.sh
-
-  echo_do bash -e ${EXTERNALIP_VALIDATION_CERT_DIR}/olcne-tranfer-certs.sh
 
 }
 

--- a/OLCNE/scripts/provision.sh
+++ b/OLCNE/scripts/provision.sh
@@ -459,8 +459,11 @@ deploy_kubernetes() {
       --nginx-image "${REGISTRY_OLCNE}/${NGINX_IMAGE}" \
       --apiserver-advertise-address "${MASTERS}" \
       --virtual-ip 192.168.99.99 \
-      --master-nodes "${master_nodes}"\
-      --worker-nodes "${worker_nodes}"
+      --master-nodes "${master_nodes}" \
+      --worker-nodes "${worker_nodes}" \
+      --restrict-service-externalip-ca-cert=${CERT_DIR}/production/ca.cert \
+      --restrict-service-externalip-tls-cert=${CERT_DIR}/production/node.cert \
+      --restrict-service-externalip-tls-key=${CERT_DIR}/production/node.key
   else
     # HA Multi-master
     echo_do olcnectl module create \
@@ -470,8 +473,11 @@ deploy_kubernetes() {
       --container-registry "${REGISTRY_OLCNE}" \
       --nginx-image "${REGISTRY_OLCNE}/${NGINX_IMAGE}" \
       --virtual-ip 192.168.99.99 \
-      --master-nodes "${master_nodes}"\
-      --worker-nodes "${worker_nodes}"
+      --master-nodes "${master_nodes}" \
+      --worker-nodes "${worker_nodes}" \
+      --restrict-service-externalip-ca-cert=${CERT_DIR}/production/ca.cert \
+      --restrict-service-externalip-tls-cert=${CERT_DIR}/production/node.cert \
+      --restrict-service-externalip-tls-key=${CERT_DIR}/production/node.key
   fi
 
   msg "Validate all required prerequisites are met for the Kubernetes module"

--- a/OLCNE/scripts/provision.sh
+++ b/OLCNE/scripts/provision.sh
@@ -14,6 +14,7 @@
 
 # Constants
 readonly CERT_DIR=/etc/olcne/pki
+readonly EXTERNALIP_VALIDATION_CERT_DIR=/etc/olcne/pki/externalip-validation-webhook
 
 #######################################
 # Convenience function used to limit output during provisioning
@@ -391,6 +392,15 @@ certificates() {
   echo_do sed -i -e "'s/^USER=.*/USER=vagrant/'"  ${CERT_DIR}/olcne-tranfer-certs.sh
 
   echo_do bash -e ${CERT_DIR}/olcne-tranfer-certs.sh
+
+  echo_do /etc/olcne/gen-certs-helper.sh --one-cert --nodes "externalip-validation-webhook-service.externalip-validation-system.svc,externalip-validation-webhook-service.externalip-validation-system.svc.cluster.local" --cert-dir "${EXTERNALIP_VALIDATION_CERT_DIR}"
+
+  echo_do sed -i -e "'s/externalip-validation-webhook-service.externalip-validation-system.svc externalip-validation-webhook-service.externalip-validation-system.svc.cluster.local/${nodes//,/ }/'" ${EXTERNALIP_VALIDATION_CERT_DIR}/olcne-tranfer-certs.sh
+
+  echo_do sed -i -e "'s/^USER=.*/USER=vagrant/'" ${EXTERNALIP_VALIDATION_CERT_DIR}/olcne-tranfer-certs.sh
+
+  echo_do bash -e ${EXTERNALIP_VALIDATION_CERT_DIR}/olcne-tranfer-certs.sh
+
 }
 
 #######################################
@@ -461,9 +471,9 @@ deploy_kubernetes() {
       --virtual-ip 192.168.99.99 \
       --master-nodes "${master_nodes}" \
       --worker-nodes "${worker_nodes}" \
-      --restrict-service-externalip-ca-cert=${CERT_DIR}/production/ca.cert \
-      --restrict-service-externalip-tls-cert=${CERT_DIR}/production/node.cert \
-      --restrict-service-externalip-tls-key=${CERT_DIR}/production/node.key
+      --restrict-service-externalip-ca-cert=${EXTERNALIP_VALIDATION_CERT_DIR}/production/ca.cert \
+      --restrict-service-externalip-tls-cert=${EXTERNALIP_VALIDATION_CERT_DIR}/production/node.cert \
+      --restrict-service-externalip-tls-key=${EXTERNALIP_VALIDATION_CERT_DIR}/production/node.key
   else
     # HA Multi-master
     echo_do olcnectl module create \
@@ -475,9 +485,9 @@ deploy_kubernetes() {
       --virtual-ip 192.168.99.99 \
       --master-nodes "${master_nodes}" \
       --worker-nodes "${worker_nodes}" \
-      --restrict-service-externalip-ca-cert=${CERT_DIR}/production/ca.cert \
-      --restrict-service-externalip-tls-cert=${CERT_DIR}/production/node.cert \
-      --restrict-service-externalip-tls-key=${CERT_DIR}/production/node.key
+      --restrict-service-externalip-ca-cert=${EXTERNALIP_VALIDATION_CERT_DIR}/production/ca.cert \
+      --restrict-service-externalip-tls-cert=${EXTERNALIP_VALIDATION_CERT_DIR}/production/node.cert \
+      --restrict-service-externalip-tls-key=${EXTERNALIP_VALIDATION_CERT_DIR}/production/node.key
   fi
 
   msg "Validate all required prerequisites are met for the Kubernetes module"


### PR DESCRIPTION
Found that current OLCNE environment is not deploying in vagrant, it fails with below error:
```
  $ vagrant up
```

![image](https://user-images.githubusercontent.com/10694338/107880789-c666e700-6ee9-11eb-8c89-ecaf5abef807.png)


Added passing of:
```
--restrict-service-externalip-ca-cert
--restrict-service-externalip-tls-cert
--restrict-service-externalip-tls-key
```
for each `olcnectl module create --module kubernetes` invocation.

Result:
![image](https://user-images.githubusercontent.com/10694338/107880319-a97ce480-6ee6-11eb-9801-6956314d98e5.png)

![image](https://user-images.githubusercontent.com/10694338/107880331-b699d380-6ee6-11eb-97a8-cf7daf4a677f.png)

```
Signed-off-by: Denis Obada <denis.o@linux.com>
```
