### PR TITLE
OLCNE: defaults EXTRA_DISK to false

### DIFF
--- a/OLCNE/Vagrantfile
+++ b/OLCNE/Vagrantfile
@@ -70,7 +70,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Creates and extra disk (/dev/sdb) so it can be used as a
   # Gluster Storage for Kubernetes Persistent Volumes
-  EXTRA_DISK = default_b('EXTRA_DISK', true)
+  EXTRA_DISK = default_b('EXTRA_DISK', false)
 
   # Override number of masters to deploy
   # This should not be changed -- for development purpose


### PR DESCRIPTION
A bit late to the 🎉 , I think that one slipped through the net...

`EXTRA_DISK` should be false by default

--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>