### PR TITLE
Handling of existing /root/.ssh

### DIFF
--- a/OLCNE/scripts/provision.sh
+++ b/OLCNE/scripts/provision.sh
@@ -346,7 +346,7 @@ passwordless_ssh() {
     echo_do ssh-keygen -t rsa -f /vagrant/id_rsa -q -N "''"
   fi
   # Install private key
-  echo_do mkdir /root/.ssh
+  echo_do mkdir -p /root/.ssh
   echo_do cp /vagrant/id_rsa /root/.ssh/
   # Authorise passwordless ssh
   echo_do cp /vagrant/id_rsa.pub /root/.ssh/authorized_keys


### PR DESCRIPTION
Updated `mkdir` call for `/root/.ssh` to not complain when the directory already exists, an annoying error which appears during re-running of provisioning steps.

```
Signed-off-by: Denis Obada <denis.o@linux.com>
```