### PR TITLE
Update deprecated project READMEs

### DIFF
--- a/ContainerTools/README.md
+++ b/ContainerTools/README.md
@@ -3,6 +3,11 @@ A Vagrantfile that installs and configures the Container Tools module on Oracle 
 
 This module provides the tools to use container runtimes. That is: mainly Podman, but also Buildah, Skopeo...
 
+__Note:__ This Vagrant project is deprecated. However, the same functionality is
+available as an extension to the OracleLinux/8 project. For more information,
+see the [Container Tools](../OracleLinux/8/README.md#container-tools) section of
+the OracleLinux/8 [README.md](../OracleLinux/8/README.md) file.
+
 ## Prerequisites
 1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 1. Install [Vagrant](https://vagrantup.com/)

--- a/DockerEngine/README.md
+++ b/DockerEngine/README.md
@@ -2,6 +2,11 @@
 
 A Vagrantfile that installs and configures Docker engine on Oracle Linux 7 with Btrfs as storage
 
+__Note:__ This Vagrant project is deprecated. However, the same functionality is
+available as an extension to the OracleLinux/7 project. For more information,
+see the [Oracle Container Runtime for Docker](../OracleLinux/7/README.md#oracle-container-runtime-for-docker)
+section of the OracleLinux/7 [README.md](../OracleLinux/7/README.md) file.
+
 ## Prerequisites
 
 Read the [prerequisites in the top level README](../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM

--- a/LAMP/README.md
+++ b/LAMP/README.md
@@ -2,6 +2,11 @@
 
 A Vagrant project that provisions Oracle Linux LAMP solution automatically, using Vagrant, an Oracle Linux 7 box and a shell script.
 
+__Note:__ This Vagrant project is deprecated. However, the same functionality is
+available as an extension to the OracleLinux/7 project. For more information,
+see the [LAMP stack](../OracleLinux/7/README.md#lamp-stack) section of the
+OracleLinux/7 [README.md](../OracleLinux/7/README.md) file.
+
 ## Prerequisites
 
 Read the [prerequisites in the top level README](../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM


### PR DESCRIPTION
Add notes to the `README.md` files for the ContainerTools, DockerEngine and LAMP projects to state that the projects are deprecated and provide links to the appropriate OracleLinux project. See the comments on #358 for background.

I'm happy to make any changes that you'd like.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>