### PR TITLE
[update] Update OLCNE code owner to rafabene

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # The last matching pattern has the most precedence.
 *                         @gvenzl
-/ContainerTools/          @AmedeeBulle          
-/OLCNE/                   @Djelibeybi
+/ContainerTools/          @AmedeeBulle
+/OLCNE/                   @rafabene
 /OracleDatabase/          @gvenzl
 /OracleLinux/             @scoter-oracle
 /OracleDG/                @rcitton


### PR DESCRIPTION
Due to internal role changes, the new owner of the OLCNE project
should now be @rafabene. 

Signed-off-by: Avi Miller <avi.miller@oracle.com>