### PR TITLE
build(metadata):  metadata for latest boxes / new btrfs boxes

### DIFF
--- a/boxes/oraclelinux/7-btrfs.json
+++ b/boxes/oraclelinux/7-btrfs.json
@@ -1,0 +1,37 @@
+{
+  "description": "Oracle Linux 7 with BTRFS root filesystem",
+  "short_description": "Oracle Linux 7 with BTRFS root fs",
+  "name": "oraclelinux/7-btrfs",
+  "versions": [
+    {
+      "version": "7.9.226",
+      "status": "active",
+      "release_date": "30-May-2021",
+      "description_html": "<ul>\n<li>Releasing 7.9.226</li>\n</ul>\n",
+      "description_markdown": "* Releasing 7.9.226",
+      "providers": [{
+        "name": "virtualbox",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol7/OL7U9_x86_64-vagrant-btrfs-virtualbox-b226.box",
+        "checksum": "1fe17919f2a011d0cbab94b417e1436dbb97f2ceaf470d0b671ef2a18d3ba81b",
+        "checksum_type": "sha256",
+        "size": 712614718,
+        "kernel": "5.4.17-2102.201.3.el7uek.x86_64"
+      }]
+    },
+    {
+      "version": "7.9.227",
+      "status": "active",
+      "release_date": "30-May-2021",
+      "description_html": "<ul>\n<li>Releasing 7.9.227</li>\n</ul>\n",
+      "description_markdown": "* Releasing 7.9.227",
+      "providers": [{
+        "name": "libvirt",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol7/OL7U9_x86_64-vagrant-btrfs-libvirt-b227.box",
+        "checksum": "5317f780fbc2dcf5e7c64d13cbc342cfb3fde8a824a7de2cad0b575fe89ca81e",
+        "checksum_type": "sha256",
+        "size": 685513295,
+        "kernel": "5.4.17-2102.201.3.el7uek.x86_64"
+      }]
+    }
+  ]
+}

--- a/boxes/oraclelinux/7.json
+++ b/boxes/oraclelinux/7.json
@@ -4,6 +4,36 @@
   "name": "oraclelinux/7",
   "versions": [
     {
+      "version": "7.9.224",
+      "status": "active",
+      "release_date": "30-May-2021",
+      "description_html": "<ul>\n<li>Refresh with UEK6U2</li>\n</ul>\n",
+      "description_markdown": "* Refresh with UEK6U2",
+      "providers": [{
+        "name": "virtualbox",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol7/OL7U9_x86_64-vagrant-virtualbox-b224.box",
+        "checksum": "fe2baa76ee8ee802a3dba1d7582f1826edfc5315558c772dce5e4c4f7eb497cc",
+        "checksum_type": "sha256",
+        "size": 599052904,
+        "kernel": "5.4.17-2102.201.3.el7uek.x86_64"
+      }]
+    },
+    {
+      "version": "7.9.228",
+      "status": "active",
+      "release_date": "31-May-2021",
+      "description_html": "<ul>\n<li>Refresh with UEK6U2</li>\n</ul>\n",
+      "description_markdown": "* Refresh with UEK6U2",
+      "providers": [{
+        "name": "libvirt",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol7/OL7U9_x86_64-vagrant-libvirt-b228.box",
+        "checksum": "e78a7670f2d36eb646bb9d9bdf86d25d898ce87f0d7d5632d7e01b43ce397f40",
+        "checksum_type": "sha256",
+        "size": 571064661,
+        "kernel": "5.4.17-2102.201.3.el7uek.x86_64"
+      }]
+    },
+    {
       "version": "7.9.194",
       "status": "active",
       "release_date": "08-Feb-2021",

--- a/boxes/oraclelinux/8-btrfs.json
+++ b/boxes/oraclelinux/8-btrfs.json
@@ -1,0 +1,37 @@
+{
+  "description": "Oracle Linux 8 with BTRFS root filesystem",
+  "short_description": "Oracle Linux 8 with BTRFS root fs",
+  "name": "oraclelinux/8-btrfs",
+  "versions": [
+    {
+      "version": "8.4.222",
+      "status": "active",
+      "release_date": "30-May-2021",
+      "description_html": "<ul>\n<li>Releasing 8.4.222</li>\n</ul>\n",
+      "description_markdown": "* Releasing 8.4.222",
+      "providers": [{
+        "name": "virtualbox",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol8/OL8U4_x86_64-vagrant-btrfs-virtualbox-b222.box",
+        "checksum": "a7c0fc600ee0e7ac1d01e4e6f0af3960a082fdadd9efbc91a1277cb6b33f18d2",
+        "checksum_type": "sha256",
+        "size": 702734822,
+        "kernel": "5.4.17-2102.201.3.el8uek.x86_64"
+      }]
+    },
+    {
+      "version": "8.4.223",
+      "status": "active",
+      "release_date": "30-May-2021",
+      "description_html": "<ul>\n<li>Releasing 8.4.223</li>\n</ul>\n",
+      "description_markdown": "* Releasing 8.4.223",
+      "providers": [{
+        "name": "libvirt",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol8/OL8U4_x86_64-vagrant-btrfs-libvirt-b223.box",
+        "checksum": "a6149554b1eaf605cd511d8d4bf9a99dde7a2d85e9eb2f9b33a9196be61b5a8f",
+        "checksum_type": "sha256",
+        "size": 673297435,
+        "kernel": "5.4.17-2102.201.3.el8uek.x86_64"
+      }]
+    }
+  ]
+}

--- a/boxes/oraclelinux/8.json
+++ b/boxes/oraclelinux/8.json
@@ -4,6 +4,36 @@
   "name": "oraclelinux/8",
   "versions": [
     {
+      "version": "8.4.220",
+      "status": "active",
+      "release_date": "30-May-2021",
+      "description_html": "<ul>\n<li>Releasing 8.4.220</li>\n</ul>\n",
+      "description_markdown": "* Releasing 8.4.220",
+      "providers": [{
+        "name": "virtualbox",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol8/OL8U4_x86_64-vagrant-virtualbox-b220.box",
+        "checksum": "544a7735ada482d451517f6d1034e1fd759a3051ba78601697754e0aa404f238",
+        "checksum_type": "sha256",
+        "size": 674085145,
+        "kernel": "5.4.17-2102.201.3.el8uek.x86_64"
+      }]
+    },
+    {
+      "version": "8.4.221",
+      "status": "active",
+      "release_date": "30-May-2021",
+      "description_html": "<ul>\n<li>Releasing 8.4.221</li>\n</ul>\n",
+      "description_markdown": "* Releasing 8.4.221",
+      "providers": [{
+        "name": "libvirt",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol8/OL8U4_x86_64-vagrant-libvirt-b221.box",
+        "checksum": "2a545cfe59ed2c37ca79279e32387622ec532e3c47ec75c0128468aee9b5feb2",
+        "checksum_type": "sha256",
+        "size": 617993437,
+        "kernel": "5.4.17-2102.201.3.el8uek.x86_64"
+      }]
+    },
+    {
       "version": "8.3.195",
       "status": "active",
       "release_date": "08-Feb-2021",


### PR DESCRIPTION
Metadata for latest boxes:

- Oracle Linux 8 Update 4 with UEK6 Update 2
- Oracle Linux 7 Update 9 with UEK6 Update 2

Also add a new flavor for the boxes: root filesystem on btrfs instead of xfs on lvm.
Boxes are named `oraclelinux/7-btrfs` and `oraclelinux/8-btrfs`.

--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>