### PR TITLE
DB projects - Correct install.sh for oratab

### DIFF
--- a/OracleDatabase/12.1.0.2/scripts/install.sh
+++ b/OracleDatabase/12.1.0.2/scripts/install.sh
@@ -143,7 +143,7 @@ rm /tmp/dbca.rsp
 
 echo 'INSTALLER: Database created'
 
-sed '$s/N/Y/' /etc/oratab | sudo tee /etc/oratab > /dev/null
+sed -i -e "\$s|${ORACLE_SID}:${ORACLE_HOME}:N|${ORACLE_SID}:${ORACLE_HOME}:Y|" /etc/oratab
 echo 'INSTALLER: Oratab configured'
 
 # configure systemd to start oracle instance on startup

--- a/OracleDatabase/12.2.0.1/scripts/install.sh
+++ b/OracleDatabase/12.2.0.1/scripts/install.sh
@@ -128,7 +128,7 @@ rm /tmp/dbca.rsp
 
 echo 'INSTALLER: Database created'
 
-sed '$s/N/Y/' /etc/oratab | sudo tee /etc/oratab > /dev/null
+sed -i -e "\$s|${ORACLE_SID}:${ORACLE_HOME}:N|${ORACLE_SID}:${ORACLE_HOME}:Y|" /etc/oratab
 echo 'INSTALLER: Oratab configured'
 
 # configure systemd to start oracle instance on startup

--- a/OracleDatabase/18.3.0/scripts/install.sh
+++ b/OracleDatabase/18.3.0/scripts/install.sh
@@ -135,7 +135,7 @@ rm /vagrant/ora-response/dbca.rsp
 
 echo 'INSTALLER: Database created'
 
-sed '$s/N/Y/' /etc/oratab | sudo tee /etc/oratab > /dev/null
+sed -i -e "\$s|${ORACLE_SID}:${ORACLE_HOME}:N|${ORACLE_SID}:${ORACLE_HOME}:Y|" /etc/oratab
 echo 'INSTALLER: Oratab configured'
 
 # configure systemd to start oracle instance on startup

--- a/OracleDatabase/19.3.0/scripts/install.sh
+++ b/OracleDatabase/19.3.0/scripts/install.sh
@@ -128,7 +128,7 @@ rm /vagrant/ora-response/dbca.rsp
 
 echo 'INSTALLER: Database created'
 
-sed '$s/N/Y/' /etc/oratab | sudo tee /etc/oratab > /dev/null
+sed -i -e "\$s|${ORACLE_SID}:${ORACLE_HOME}:N|${ORACLE_SID}:${ORACLE_HOME}:Y|" /etc/oratab
 echo 'INSTALLER: Oratab configured'
 
 # configure systemd to start oracle instance on startup


### PR DESCRIPTION
Modify the `install.sh` command that updates `/etc/oratab` for the OracleDatabase/12.1.0.2, OracleDatabase/12.2.0.1, OracleDatabase/18.3.0, and OracleDatabase/19.3.0 projects to ensure that it changes the correct "N" character. Fixes #370.

To test, configure the installation to use a SID name and/or an ORACLE_HOME directory name containing an "N" character. Build the VM, and verify that only the last "N" character on the last line of `/etc/oratab` has been changed to "Y".

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>