### PR TITLE
Add OracleDatabase/21.3.0 project

### DIFF
--- a/OracleDatabase/21.3.0/.env
+++ b/OracleDatabase/21.3.0/.env
@@ -1,0 +1,50 @@
+# Oracle Database 21.3.0 configuration file
+#
+# Requires vagrant-env plugin
+#
+# This file will be overwritten on updates, so it is recommended to make
+# a copy of this file called .env.local, then make changes in .env.local.
+#
+# To change a parameter, uncomment it and set it to the desired value.
+# All commented parameters will retain their default values.
+
+# VM name
+# VM_NAME='oracle-21c-vagrant'
+
+# Memory for the VM (in MB, 2560 MB = 2.5 GB)
+# VM_MEMORY=2560
+
+# VM time zone
+# If not specified, will be set to match host time zone (if possible)
+# Can use time zone name (e.g., 'America/Los_Angeles')
+# or an offset from GMT (e.g., 'Etc/GMT-2')
+# VM_SYSTEM_TIMEZONE=
+
+# Oracle base directory
+# VM_ORACLE_BASE='/opt/oracle'
+
+# Oracle home directory
+# VM_ORACLE_HOME='/opt/oracle/product/21c/dbhome_1'
+
+# Oracle SID
+# VM_ORACLE_SID='ORCLCDB'
+
+# PDB name
+# VM_ORACLE_PDB='ORCLPDB1'
+
+# Database character set
+# VM_ORACLE_CHARACTERSET='AL32UTF8'
+
+# Oracle Database edition
+# Valid values are 'EE' for Enterprise Edition or 'SE2' for Standard Edition 2
+# VM_ORACLE_EDITION='EE'
+
+# Listener port
+# VM_LISTENER_PORT=1521
+
+# EM Express port
+# VM_EM_EXPRESS_PORT=5500
+
+# Oracle Database password for SYS, SYSTEM and PDBADMIN accounts
+# If left blank, the password will be generated automatically
+# VM_ORACLE_PWD=

--- a/OracleDatabase/21.3.0/.gitattributes
+++ b/OracleDatabase/21.3.0/.gitattributes
@@ -1,0 +1,1 @@
+*.sh	text eol=lf

--- a/OracleDatabase/21.3.0/.gitignore
+++ b/OracleDatabase/21.3.0/.gitignore
@@ -1,0 +1,1 @@
+.env.local*

--- a/OracleDatabase/21.3.0/README.md
+++ b/OracleDatabase/21.3.0/README.md
@@ -1,0 +1,110 @@
+# oracle-21c-vagrant
+
+This Vagrant project provisions Oracle Database automatically, using Vagrant, an Oracle Linux 8 box and a shell script.
+
+## Prerequisites
+
+1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
+2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
+makes configuration much easier
+
+## Getting started
+
+1. Clone this repository `git clone https://github.com/oracle/vagrant-projects`
+2. Change into the `vagrant-projects/OracleDatabase/21.3.0` directory
+3. Download the installation zip file (`LINUX.X64_213000_db_home.zip`) from OTN into this directory - first time only:
+[http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html](http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html)
+4. Run `vagrant up`
+   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the VM to the latest via `yum`.
+   2. The installation can be customized, if desired (see [Configuration](#configuration)).
+5. Connect to the database (see [Connecting to Oracle](#connecting-to-oracle))
+6. You can shut down the VM via the usual `vagrant halt` and then start it up again via `vagrant up`
+
+## Connecting to Oracle
+
+The default database connection parameters are:
+
+* Hostname: `localhost`
+* Port: `1521`
+* SID: `ORCLCDB`
+* PDB: `ORCLPDB1`
+* EM Express port: `5500`
+* Database passwords are auto-generated and printed on install
+
+These parameters can be customized, if desired (see [Configuration](#configuration)).
+
+## Resetting password
+
+You can reset the password of the Oracle database accounts (SYS, SYSTEM and PDBADMIN only) by switching to the oracle user (`sudo su - oracle`), then executing `/home/oracle/setPassword.sh <Your new password>`.
+
+## Running scripts after setup
+
+You can have the installer run scripts after setup by putting them in the `userscripts` directory below the directory where you have this file checked out. Any shell (`.sh`) or SQL (`.sql`) scripts you put in the `userscripts` directory will be executed by the installer after the database is set up and started. Only shell and SQL scripts will be executed; all other files will be ignored. These scripts are completely optional.
+
+Shell scripts will be executed as root. SQL scripts will be executed as SYS. SQL scripts will run against the CDB, not the PDB, unless you include an `ALTER SESSION SET CONTAINER = <pdbname>` statement in the script.
+
+To run scripts in a specific order, prefix the file names with a number, e.g., `01_shellscript.sh`, `02_tablespaces.sql`, `03_shellscript2.sh`, etc.
+
+## Configuration
+
+The `Vagrantfile` can be used _as-is_, without any additional configuration. However, there are several parameters you can set to tailor the installation to your needs.
+
+### How to configure
+
+There are three ways to set parameters:
+
+1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
+2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
+3. Use the `.env`/`.env.local` files (requires
+[vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
+
+Parameters are considered in the following order (first one wins):
+
+1. Environment variables
+2. `.env.local` (if it exists and the  [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
+3. `.env` (if the [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
+4. `Vagrantfile` definitions
+
+### VM parameters
+
+* `VM_NAME` (default: `oracle-21c-vagrant`): VM name.
+* `VM_MEMORY` (default: `2560`): memory for the VM (in MB, 2560 MB = 2.5 GB).
+* `VM_SYSTEM_TIMEZONE` (default: host time zone (if possible)): VM time zone.
+  * The system time zone is used by the database for SYSDATE/SYSTIMESTAMP.
+  * The guest time zone will be set to the host time zone when the host time zone is a full hour offset from GMT.
+  * When the host time zone isn't a full hour offset from GMT (e.g., in India and parts of Australia), the guest time zone will be set to UTC.
+  * You can specify a different time zone using a time zone name (e.g., "America/Los_Angeles") or an offset from GMT (e.g., "Etc/GMT-2"). For more information on specifying time zones, see [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
+### Oracle Database parameters
+
+* `VM_ORACLE_BASE` (default: `/opt/oracle/`): Oracle base directory.
+* `VM_ORACLE_HOME` (default: `/opt/oracle/product/21c/dbhome_1`): Oracle home directory.
+* `VM_ORACLE_SID` (default: `ORCLCDB`): Oracle SID.
+* `VM_ORACLE_PDB` (default: `ORCLPDB1`): PDB name.
+* `VM_ORACLE_CHARACTERSET` (default: `AL32UTF8`): database character set.
+* `VM_ORACLE_EDITION` (default: `EE`): Oracle Database edition. Either `EE` for Enterprise Edition or `SE2` for Standard Edition 2.
+* `VM_LISTENER_PORT` (default: `1521`): Listener port.
+* `VM_EM_EXPRESS_PORT` (default: `5500`): EM Express port.
+* `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS, SYSTEM and PDBADMIN accounts.
+
+## Optional plugins
+
+When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+
+* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
+variables from .env files;
+* [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
+proxies in the guest VM if you need to access the Internet through a proxy. See
+the plugin documentation for configuration.
+
+To install Vagrant plugins run:
+
+```shell
+vagrant plugin install <name>...
+```
+
+## Other info
+
+* If you need to, you can connect to the virtual machine via `vagrant ssh`.
+* You can `sudo su - oracle` to switch to the oracle user.
+* On the guest OS, the directory `/vagrant` is a shared folder and maps to wherever you have this file checked out.

--- a/OracleDatabase/21.3.0/Vagrantfile
+++ b/OracleDatabase/21.3.0/Vagrantfile
@@ -1,0 +1,179 @@
+#
+# LICENSE UPL 1.0
+#
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates.
+#
+# Since: July, 2018
+# Author: gerald.venzl@oracle.com
+# Description: Creates an Oracle database Vagrant virtual machine.
+# Optional plugins:
+#     vagrant-env (use .env files for configuration)
+#     vagrant-proxyconf (if you don't have direct access to the Internet)
+#         see https://github.com/tmatilai/vagrant-proxyconf for configuration
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+# Box metadata location and box name
+BOX_URL = "https://oracle.github.io/vagrant-projects/boxes"
+BOX_NAME = "oraclelinux/8"
+
+# UI object for printing information
+ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
+
+# Define constants
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Use vagrant-env plugin if available
+  if Vagrant.has_plugin?("vagrant-env")
+    config.env.load(".env.local", ".env") # enable the plugin
+  end
+
+  # VM name
+  VM_NAME = default_s('VM_NAME', 'oracle-21c-vagrant')
+
+  # Memory for the VM (in MB, 2560 MB = 2.5 GB)
+  VM_MEMORY = default_i('VM_MEMORY', 2560)
+
+  # VM time zone
+  # If not specified, will be set to match host time zone (if possible)
+  VM_SYSTEM_TIMEZONE = default_s('VM_SYSTEM_TIMEZONE', host_tz)
+
+  # Oracle base directory
+  VM_ORACLE_BASE = default_s('VM_ORACLE_BASE', '/opt/oracle')
+
+  # Oracle home directory
+  VM_ORACLE_HOME = default_s('VM_ORACLE_HOME', '/opt/oracle/product/21c/dbhome_1')
+
+  # Oracle SID
+  VM_ORACLE_SID = default_s('VM_ORACLE_SID', 'ORCLCDB')
+
+  # PDB name
+  VM_ORACLE_PDB = default_s('VM_ORACLE_PDB', 'ORCLPDB1')
+
+  # Database character set
+  VM_ORACLE_CHARACTERSET = default_s('VM_ORACLE_CHARACTERSET', 'AL32UTF8')
+
+  # Oracle Database edition
+  # Valid values are 'EE' for Enterprise Edition or 'SE2' for Standard Edition 2
+  VM_ORACLE_EDITION = default_s('VM_ORACLE_EDITION', 'EE')
+
+  # Listener port
+  VM_LISTENER_PORT = default_i('VM_LISTENER_PORT', 1521)
+
+  # EM Express port
+  VM_EM_EXPRESS_PORT = default_i('VM_EM_EXPRESS_PORT', 5500)
+
+  # Oracle Database password for SYS, SYSTEM and PDBADMIN accounts
+  # If left blank, the password will be generated automatically
+  VM_ORACLE_PWD = default_s('VM_ORACLE_PWD', '')
+end
+
+# Convenience methods
+def default_s(key, default)
+  ENV[key] && ! ENV[key].empty? ? ENV[key] : default
+end
+
+def default_i(key, default)
+  default_s(key, default).to_i
+end
+
+def host_tz
+  # get host time zone for setting VM time zone
+  # if host time zone isn't an integer hour offset from GMT, fall back to UTC
+  offset_sec = Time.now.gmt_offset
+  if (offset_sec % (60 * 60)) == 0
+    offset_hr = ((offset_sec / 60) / 60)
+    timezone_suffix = offset_hr >= 0 ? "-#{offset_hr.to_s}" : "+#{(-offset_hr).to_s}"
+    'Etc/GMT' + timezone_suffix
+  else
+    'UTC'
+  end
+end
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = BOX_NAME
+  config.vm.box_url = "#{BOX_URL}/#{BOX_NAME}.json"
+  config.vm.define VM_NAME
+
+  # Provider-specific configuration
+  config.vm.provider "virtualbox" do |v|
+    v.memory = VM_MEMORY
+    v.name = VM_NAME
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = VM_MEMORY
+  end
+
+  # add proxy configuration from host env - optional
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+    ui.info "Getting Proxy Configuration from Host..."
+    has_proxy = false
+    ["http_proxy", "HTTP_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTP proxy: " + proxy
+        config.proxy.http = proxy
+        has_proxy = true
+        break
+      end
+    end
+
+    ["https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTPS proxy: " + proxy
+        config.proxy.https = proxy
+        has_proxy = true
+        break
+      end
+    end
+
+    if has_proxy
+      # Only consider no_proxy if we have proxies defined.
+      no_proxy = ""
+      ["no_proxy", "NO_PROXY"].each do |proxy_var|
+        if ENV[proxy_var]
+          no_proxy = ENV[proxy_var]
+          ui.info "No proxy: " + no_proxy
+          no_proxy += ","
+          break
+        end
+      end
+      config.proxy.no_proxy = no_proxy + "localhost,127.0.0.1"
+    end
+  else
+    ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if ENV[proxy_var]
+        ui.warn 'To enable proxies in your VM, install the vagrant-proxyconf plugin'
+        break
+      end
+    end
+  end
+
+  # VM hostname
+  config.vm.hostname = VM_NAME
+
+  # Oracle port forwarding
+  config.vm.network "forwarded_port", guest: VM_LISTENER_PORT, host: VM_LISTENER_PORT
+  config.vm.network "forwarded_port", guest: VM_EM_EXPRESS_PORT, host: VM_EM_EXPRESS_PORT
+
+  # Provision everything on the first run
+  config.vm.provision "shell", path: "scripts/install.sh", env:
+    {
+       "SYSTEM_TIMEZONE"     => VM_SYSTEM_TIMEZONE,
+       "ORACLE_BASE"         => VM_ORACLE_BASE,
+       "ORACLE_HOME"         => VM_ORACLE_HOME,
+       "ORACLE_SID"          => VM_ORACLE_SID,
+       "ORACLE_PDB"          => VM_ORACLE_PDB,
+       "ORACLE_CHARACTERSET" => VM_ORACLE_CHARACTERSET,
+       "ORACLE_EDITION"      => VM_ORACLE_EDITION,
+       "LISTENER_PORT"       => VM_LISTENER_PORT,
+       "EM_EXPRESS_PORT"     => VM_EM_EXPRESS_PORT,
+       "ORACLE_PWD"          => VM_ORACLE_PWD
+    }
+
+end

--- a/OracleDatabase/21.3.0/ora-response/db_install.rsp.tmpl
+++ b/OracleDatabase/21.3.0/ora-response/db_install.rsp.tmpl
@@ -1,0 +1,12 @@
+oracle.install.responseFileVersion=/oracle/install/rspfmt_dbinstall_response_schema_v21.0.0
+oracle.install.option=INSTALL_DB_SWONLY
+UNIX_GROUP_NAME=dba
+INVENTORY_LOCATION=###INVENTORY_LOCATION###
+ORACLE_BASE=###ORACLE_BASE###
+ORACLE_HOME=###ORACLE_HOME###
+oracle.install.db.InstallEdition=###ORACLE_EDITION###
+oracle.install.db.OSDBA_GROUP=dba
+oracle.install.db.OSBACKUPDBA_GROUP=dba
+oracle.install.db.OSDGDBA_GROUP=dba
+oracle.install.db.OSKMDBA_GROUP=dba
+oracle.install.db.OSRACDBA_GROUP=dba

--- a/OracleDatabase/21.3.0/ora-response/dbca.rsp.tmpl
+++ b/OracleDatabase/21.3.0/ora-response/dbca.rsp.tmpl
@@ -1,0 +1,22 @@
+responseFileVersion=/oracle/assistants/rspfmt_dbca_response_schema_v21.0.0
+gdbName=###ORACLE_SID###
+sid=###ORACLE_SID###
+databaseConfigType=SI
+createAsContainerDatabase=true
+numberOfPDBs=1
+pdbName=###ORACLE_PDB###
+pdbAdminPassword=###ORACLE_PWD###
+templateName=General_Purpose.dbc
+sysPassword=###ORACLE_PWD###
+systemPassword=###ORACLE_PWD###
+emConfiguration=DBEXPRESS
+emExpressPort=###EM_EXPRESS_PORT###
+dbsnmpPassword=###ORACLE_PWD###
+storageType=FS
+characterSet=###ORACLE_CHARACTERSET###
+nationalCharacterSet=AL16UTF16
+automaticMemoryManagement=FALSE
+totalMemory=1536
+# Some init.ora parameters - disable auditing to save space, enable FS optimizations
+initParams=audit_trail=none,audit_sys_operations=false,filesystemio_options=setall,commit_logging=batch,commit_wait=nowait
+

--- a/OracleDatabase/21.3.0/scripts/install.sh
+++ b/OracleDatabase/21.3.0/scripts/install.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+#
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Since: July, 2018
+# Author: gerald.venzl@oracle.com
+# Description: Installs Oracle database software
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+# Abort on any error
+set -Eeuo pipefail
+
+echo 'INSTALLER: Started up'
+
+# get up to date
+dnf upgrade -y
+
+echo 'INSTALLER: System updated'
+
+# fix locale warning
+dnf reinstall -y glibc-common
+echo 'LANG=en_US.utf-8' >> /etc/environment
+echo 'LC_ALL=en_US.utf-8' >> /etc/environment
+
+echo 'INSTALLER: Locale set'
+
+# set system time zone
+timedatectl set-timezone "$SYSTEM_TIMEZONE"
+echo "INSTALLER: System time zone set to $SYSTEM_TIMEZONE"
+
+# Install Oracle Database prereq and openssl packages
+dnf install -y oracle-database-preinstall-21c openssl
+
+echo 'INSTALLER: Oracle preinstall and openssl complete'
+
+# create directories
+mkdir -p "$ORACLE_HOME"
+mkdir -p /u01/app
+ln -s "$ORACLE_BASE" /u01/app/oracle
+inventory_location=$(realpath "$ORACLE_BASE"/../oraInventory)
+mkdir -p "$inventory_location"
+
+echo 'INSTALLER: Oracle directories created'
+
+# set environment variables
+# shellcheck disable=SC2153
+cat >> /home/oracle/.bashrc << EOF
+export ORACLE_BASE=$ORACLE_BASE
+export ORACLE_HOME=$ORACLE_HOME
+export ORACLE_SID=$ORACLE_SID
+export PATH=\$PATH:\$ORACLE_HOME/bin
+EOF
+
+echo 'INSTALLER: Environment variables set'
+
+# Install Oracle
+
+unzip /vagrant/LINUX.X64_213000_db_home.zip -d "$ORACLE_HOME"/
+cp /vagrant/ora-response/db_install.rsp.tmpl /tmp/db_install.rsp
+sed -i -e "s|###INVENTORY_LOCATION###|$inventory_location|g" /tmp/db_install.rsp
+sed -i -e "s|###ORACLE_BASE###|$ORACLE_BASE|g" /tmp/db_install.rsp
+sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" /tmp/db_install.rsp
+sed -i -e "s|###ORACLE_EDITION###|$ORACLE_EDITION|g" /tmp/db_install.rsp
+chown oracle:oinstall -R "$ORACLE_BASE" "$inventory_location"
+
+# runInstaller should return 6 (successful with warnings) when prereqs are ignored
+su -l oracle -c "yes | $ORACLE_HOME/runInstaller -silent -ignorePrereqFailure -waitforcompletion -responseFile /tmp/db_install.rsp" || {
+  ret=$?
+  if [[ $ret -ne 6 ]]; then
+    echo 'Oracle Database installer exited with error!'
+    exit $ret;
+  fi;
+}
+
+"$inventory_location"/orainstRoot.sh
+"$ORACLE_HOME"/root.sh
+rm /tmp/db_install.rsp
+
+echo 'INSTALLER: Oracle software installed'
+
+# create sqlnet.ora, listener.ora and tnsnames.ora
+network_admin_dir=$("$ORACLE_HOME"/bin/orabasehome)/network/admin
+su -l oracle -c "mkdir -p $network_admin_dir"
+su -l oracle -c "echo 'NAME.DIRECTORY_PATH= (TNSNAMES, EZCONNECT, HOSTNAME)' > $network_admin_dir/sqlnet.ora"
+
+# Listener.ora
+su -l oracle -c "echo 'LISTENER =
+(DESCRIPTION_LIST =
+  (DESCRIPTION =
+    (ADDRESS = (PROTOCOL = IPC)(KEY = EXTPROC1))
+    (ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = $LISTENER_PORT))
+  )
+)
+
+DEDICATED_THROUGH_BROKER_LISTENER=ON
+DIAG_ADR_ENABLED = off
+' > $network_admin_dir/listener.ora"
+
+su -l oracle -c "echo '$ORACLE_SID=localhost:$LISTENER_PORT/$ORACLE_SID' > $network_admin_dir/tnsnames.ora"
+# shellcheck disable=SC2153
+su -l oracle -c "echo '$ORACLE_PDB=
+(DESCRIPTION =
+  (ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = $LISTENER_PORT))
+  (CONNECT_DATA =
+    (SERVER = DEDICATED)
+    (SERVICE_NAME = $ORACLE_PDB)
+  )
+)' >> $network_admin_dir/tnsnames.ora"
+
+# Start LISTENER
+su -l oracle -c 'lsnrctl start'
+
+echo 'INSTALLER: Listener created'
+
+# Create database
+
+# Auto generate ORACLE PWD if not passed in
+export ORACLE_PWD=${ORACLE_PWD:-"$(openssl rand -base64 8)1"}
+
+cp /vagrant/ora-response/dbca.rsp.tmpl /tmp/dbca.rsp
+sed -i -e "s|###ORACLE_SID###|$ORACLE_SID|g" /tmp/dbca.rsp
+sed -i -e "s|###ORACLE_PDB###|$ORACLE_PDB|g" /tmp/dbca.rsp
+sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" /tmp/dbca.rsp
+sed -i -e "s|###ORACLE_PWD###|$ORACLE_PWD|g" /tmp/dbca.rsp
+sed -i -e "s|###EM_EXPRESS_PORT###|$EM_EXPRESS_PORT|g" /tmp/dbca.rsp
+
+# Create DB
+su -l oracle -c 'dbca -silent -createDatabase -responseFile /tmp/dbca.rsp'
+
+# Post DB setup tasks
+su -l oracle -c "sqlplus / as sysdba << EOF
+   ALTER PLUGGABLE DATABASE $ORACLE_PDB SAVE STATE;
+   EXEC DBMS_XDB_CONFIG.SETGLOBALPORTENABLED (TRUE);
+   ALTER SYSTEM SET LOCAL_LISTENER = '(ADDRESS = (PROTOCOL = TCP)(HOST = 0.0.0.0)(PORT = $LISTENER_PORT))' SCOPE=BOTH;
+   ALTER SYSTEM REGISTER;
+   exit
+EOF"
+
+rm /tmp/dbca.rsp
+
+echo 'INSTALLER: Database created'
+
+sed -i -e "\$s|${ORACLE_SID}:${ORACLE_HOME}:N|${ORACLE_SID}:${ORACLE_HOME}:Y|" /etc/oratab
+echo 'INSTALLER: Oratab configured'
+
+# configure systemd to start oracle instance on startup
+cp /vagrant/scripts/oracle-rdbms.service /etc/systemd/system/
+sed -i -e "s|###ORACLE_HOME###|$ORACLE_HOME|g" /etc/systemd/system/oracle-rdbms.service
+systemctl daemon-reload
+systemctl enable oracle-rdbms
+systemctl start oracle-rdbms
+echo "INSTALLER: Created and enabled oracle-rdbms systemd's service"
+
+cp /vagrant/scripts/setPassword.sh /home/oracle/
+chown oracle:oinstall /home/oracle/setPassword.sh
+chmod u=rwx,go=r /home/oracle/setPassword.sh
+
+echo 'INSTALLER: setPassword.sh file setup'
+
+# run user-defined post-setup scripts
+echo 'INSTALLER: Running user-defined post-setup scripts'
+
+for f in /vagrant/userscripts/*
+  do
+    case "${f,,}" in
+      *.sh)
+        echo "INSTALLER: Running $f"
+        # shellcheck disable=SC1090
+        . "$f"
+        echo "INSTALLER: Done running $f"
+        ;;
+      *.sql)
+        echo "INSTALLER: Running $f"
+        su -l oracle -c "echo 'exit' | sqlplus -s / as sysdba @\"$f\""
+        echo "INSTALLER: Done running $f"
+        ;;
+      /vagrant/userscripts/put_custom_scripts_here.txt)
+        :
+        ;;
+      *)
+        echo "INSTALLER: Ignoring $f"
+        ;;
+    esac
+  done
+
+echo 'INSTALLER: Done running user-defined post-setup scripts'
+
+echo "ORACLE PASSWORD FOR SYS, SYSTEM AND PDBADMIN: $ORACLE_PWD"
+
+echo 'INSTALLER: Installation complete, database ready to use!'

--- a/OracleDatabase/21.3.0/scripts/oracle-rdbms.service
+++ b/OracleDatabase/21.3.0/scripts/oracle-rdbms.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Oracle Database(s) and Listener
+Requires=network.target
+
+[Service]
+Type=forking
+Restart=no
+ExecStart=###ORACLE_HOME###/bin/dbstart ###ORACLE_HOME###
+ExecStop=###ORACLE_HOME###/bin/dbshut ###ORACLE_HOME###
+User=oracle
+
+[Install]
+WantedBy=multi-user.target

--- a/OracleDatabase/21.3.0/scripts/setPassword.sh
+++ b/OracleDatabase/21.3.0/scripts/setPassword.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+# 
+# Since: November, 2016
+# Author: gerald.venzl@oracle.com
+# Description: Sets the password for sys, system and pdb_admin
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# 
+
+ORACLE_PWD=$1
+ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
+ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v pdbseed | awk '{print $9}' | cut -d/ -f6`"
+ORAENV_ASK=NO
+source oraenv
+
+sqlplus / as sysdba << EOF
+      ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
+      ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
+      ALTER SESSION SET CONTAINER=$ORACLE_PDB;
+      ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD";
+      exit;
+EOF
+

--- a/OracleDatabase/21.3.0/userscripts/.gitignore
+++ b/OracleDatabase/21.3.0/userscripts/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!put_custom_scripts_here.txt

--- a/OracleDatabase/21.3.0/userscripts/put_custom_scripts_here.txt
+++ b/OracleDatabase/21.3.0/userscripts/put_custom_scripts_here.txt
@@ -1,0 +1,14 @@
+Any shell (.sh) or SQL (.sql) scripts you put in this directory
+will be executed by the installer after the database is set up
+and started.  Only shell and SQL scripts will be executed; all
+other files will be ignored.  These scripts are completely
+optional.
+
+Shell scripts will be executed as root.  SQL scripts will be
+executed as SYS.  SQL scripts will run against the CDB, not the
+PDB, unless you include an ALTER SESSION SET CONTAINER = <pdbname>
+statement in the script.
+
+To run scripts in a specific order, prefix the file names with a
+number, e.g., 01_shellscript.sh, 02_tablespaces.sql,
+03_shellscript2.sh, etc.


### PR DESCRIPTION
Adds an OracleDatabase/21.3.0 project, based on the OracleDatabase/19.3.0 project.

Notable changes from the 19.3.0 project:

- Use Oracle Linux 8 instead of Oracle Linux 7
- Increase default VM memory to 2.5 GB to avoid DBCA warning
- Move oraInventory out of the ORACLE_BASE directory, as recommended in the documentation
- 21c Oracle homes are read-only by default, so create network configuration files in ORACLE_BASE_HOME/network/admin, instead of ORACLE_HOME/network/admin
- install.sh script:
  - Address all ShellCheck warnings
  - Remove unnecessary use of sudo (script runs as root)
  - Use /tmp for db_install and dbca response files. This ensures that the response files aren't left under /vagrant if an error occurs.
  - Ensure that permissions on setPassword.sh are set correctly
  - Minor formatting fixes (trailing spaces, single vs. double quotes, etc.)

Tested with both VirtualBox and libvirt/KVM. Closes #374.

I'm happy to make any changes that you'd like.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>