### PR TITLE
409 fixes

### DIFF
--- a/OLCNE/.env
+++ b/OLCNE/.env
@@ -1,3 +1,6 @@
+# -*- mode: shell-script -*-
+# vi: set ft=shell :
+
 # Oracle Linux Cloud Native Environment configuration file
 #
 # Requires vagrant-env plugin
@@ -8,9 +11,13 @@
 # Verbose console
 # VERBOSE=false
 
-# Set vCPU count and memory for the VMs (3GB minimum required for Istio)
-# CPUS=2
-# MEMORY=3072
+# Set vCPU count and memory for the VMs (2 vCPU/2GB memory minimum for Master node) (3GB minimum required for Istio)
+# OPERATOR_CPUS=1
+# OPERATOR_MEMORY=1024
+# MASTER_CPUS=2
+# MASTER_MEMORY=2048
+# WORKER_CPUS=1
+# WORKER_MEMORY=1024
 
 # Group VirtualBox containers
 # VB_GROUP="OLCNE"
@@ -26,7 +33,7 @@
 
 # Creates an extra disk (/dev/sdb) so it can be used as a
 # Gluster Storage for Kubernetes Persistent Volumes
-# EXTRA_DISK = false
+# EXTRA_DISK=false
 
 # Number of worker nodes to provision
 # NB_WORKERS=2
@@ -63,3 +70,6 @@
 # Override number of masters to deploy
 # This should not be changed -- for development purpose
 # NB_MASTERS=1
+
+# Update OS and Reboot
+# UPDATE_OS=false

--- a/OLCNE/README.md
+++ b/OLCNE/README.md
@@ -16,7 +16,7 @@ Environment Platform Agent installed and configured to communicate with the
 Platform API Server on the operator node.
 
 The installation includes the Kubernetes module for Oracle Linux Cloud
-Native Environment which deploys Kubernetes 1.18.10 configured to use
+Native Environment which deploys Kubernetes 1.21.6 configured to use
 the CRI-O runtime interface. Two runtime engines are installed, runc and
 Kata Containers.
 
@@ -98,7 +98,12 @@ is installed)
 ### VM parameters
 
 - `VERBOSE` (default: `false`): verbose output during VM deployment.
-- `MEMORY` (default: 3072): all VMs are provisioned with 3GB memory.
+- `WORKER_CPUS` (default: 1):  Provision Worker Node with 1 vCPU.
+- `WORKER_MEMORY` (default: 1024): Provision Worker Node with 1GB memory.
+- `MASTER_CPUS` (default: 2): At least 2 vCPUS are required for Master Nodes.
+- `MASTER_MEMORY` (default: 2048): At least 1700MB are required for Master Nodes.
+- `OPERATOR_CPUS` (default: 1): Only applicable if `STANDALONE_OPERATOR=true`.
+- `OPERATOR_MEMORY` (default: 1024): Only applicable if `STANDALONE_OPERATOR=true`.
 - `VB_GROUP` (default: `OLCNE`): group all VirtualBox VMs under this label.
 - `EXTRA_DISK` (default: `false`): Creates an extra disk (/dev/sdb) that can be used for GlusterFS for Kubernetes Persistent Volumes
 

--- a/OLCNE/Vagrantfile
+++ b/OLCNE/Vagrantfile
@@ -46,9 +46,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.env.load(".env.local", ".env") # enable the plugin
   end
 
-  # vCPUS (2) and Memory for the VMs (3GB)
-  CPUS = default_i('CPUS', 2)
-  MEMORY = default_i("MEMORY", 3072)
+  # vCPUS and Memory for the VMs
+  OPERATOR_CPUS = default_i('OPERATOR_CPUS', 1)
+  OPERATOR_MEMORY = default_i("OPERATOR_MEMORY", 1024)
+  MASTER_CPUS = default_i('MASTER_CPUS', 2)
+  MASTER_MEMORY = default_i("MASTER_MEMORY", 2048)
+  WORKER_CPUS = default_i('WORKER_CPUS', 1)
+  WORKER_MEMORY = default_i("WORKER_MEMORY", 1024)
 
   # Group VirtualBox containers
   VB_GROUP = default_s("VB_GROUP", "OLCNE")
@@ -113,6 +117,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Use specific component version (mainly used for development)
   NGINX_IMAGE = default_s('NGINX_IMAGE', 'nginx:1.17.7')
 
+  # Update OS and Reboot
+  UPDATE_OS = default_b('UPDATE_OS', false)
+  
   # Verbose console
   VERBOSE = default_b('VERBOSE', false)
 end
@@ -132,6 +139,15 @@ end
 
 def ensure_scheme(url)
   (url =~ /.*:\/\// ? "" : "http://") + url
+end
+
+def update_os(vm)
+  if UPDATE_OS
+    vm.provision :shell,
+                 inline: "dnf -y update",
+                 privileged: true,
+                 reboot: true
+  end
 end
 
 def provision_vm(vm, vm_args)
@@ -197,8 +213,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Provider-specific configuration -- VirtualBox
   config.vm.provider "virtualbox" do |vb, override|
-    vb.memory = MEMORY
-    vb.cpus = CPUS
     vb.customize ["modifyvm", :id, "--groups", "/" + VB_GROUP]
     vb.customize ["modifyvm", :id, "--nested-hw-virt", "on"]
     if EXTRA_DISK
@@ -206,8 +220,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
   config.vm.provider :libvirt do |lv|
-    lv.memory = MEMORY
-    lv.cpus = CPUS
     lv.nested = true
     if EXTRA_DISK
       lv.storage :file, :size => '16G', :type => 'qcow2'
@@ -226,7 +238,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       if Vagrant.has_plugin?("vagrant-hosts")
         worker.vm.provision :hosts, :sync_hosts => true, :add_localhost_hostnames => false
       end
-      # Provisioning: install stuff
+      worker.vm.provider "virtualbox" do |vb, override|
+        vb.memory = WORKER_MEMORY
+        vb.cpus = WORKER_CPUS
+      end
+      config.vm.provider :libvirt do |lv|
+        lv.memory = WORKER_MEMORY
+        lv.cpus = WORKER_CPUS
+      end
+      # Update OS if UPDATE_OS=true
+      update_os(worker.vm)
+      # Provisioning: Worker Node
       provision_vm(worker.vm, ["--worker"])
     end
   end
@@ -243,11 +265,21 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       if Vagrant.has_plugin?("vagrant-hosts")
         master.vm.provision :hosts, :sync_hosts => true, :add_localhost_hostnames => false
       end
+      master.vm.provider "virtualbox" do |vb, override|
+        vb.memory = MASTER_MEMORY
+        vb.cpus = MASTER_CPUS
+      end
+      config.vm.provider :libvirt do |lv|
+        lv.memory = MASTER_MEMORY
+        lv.cpus = MASTER_CPUS
+      end
       if BIND_PROXY && i == 1
         # Bind kubectl proxy proxy port
         master.vm.network "forwarded_port", guest: 8001, host: 8001
       end
-      # Provisioning: install stuff
+      # Update OS if UPDATE_OS=true
+      update_os(master.vm)
+      # Provisioning: Master Node
       args = ["--master", "--nginx-image", NGINX_IMAGE]
       if !STANDALONE_OPERATOR && i == 1
         args.push("--operator")
@@ -266,6 +298,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       if Vagrant.has_plugin?("vagrant-hosts")
         operator.vm.provision :hosts, :sync_hosts => true, :add_localhost_hostnames => false
       end
+      operator.vm.provider "virtualbox" do |vb, override|
+        vb.memory = OPERATOR_MEMORY
+        vb.cpus = OPERATOR_CPUS
+      end
+      config.vm.provider :libvirt do |lv|
+        lv.memory = OPERATOR_MEMORY
+        lv.cpus = OPERATOR_CPUS
+      end
+      # Update OS if UPDATE_OS=true
+      update_os(operator.vm)
+      # Provisioning: Operator Node
       args = ["--operator"]
       args.push("--workers", workers.chop)
       args.push("--masters", masters.chop)

--- a/OLCNE/scripts/provision.sh
+++ b/OLCNE/scripts/provision.sh
@@ -217,8 +217,8 @@ setup_repos() {
 
   # Add OLCNE release package
   echo_do dnf install -y oracle-olcne-release-el8
-  echo_do dnf config-manager --enable ol8_olcne13 ol8_addons ol8_baseos_latest ol8_UEKR6
-  echo_do dnf config-manager --disable ol8_olcne12
+  echo_do dnf config-manager --enable ol8_olcne14 ol8_addons ol8_baseos_latest ol8_UEKR6
+  echo_do dnf config-manager --disable ol8_olcne12 ol8_olcne13
 
   # Optional extra repo
   if [[ -n ${EXTRA_REPO} ]]; then echo_do dnf config-manager --add-repo "${EXTRA_REPO}"; fi


### PR DESCRIPTION
The changes include:
- Ability to set different CPU and Memory for Master / Worker (or Operator) nodes. [Issue#409](https://github.com/oracle/vagrant-projects/issues/409)
- Bumped [OLCNE to v1.4](https://docs.oracle.com/en/operating-systems/olcne/1.4/start/prereq.html#ol8)
- Added a new `UPDATE_OS` _option_ to Update and Reboot the VM Node. Defaults to `false`

Signed-off-by: Hussam Qasem <hqasem@tyeb.com>