### PR TITLE
feat(olcne): deploy GlusterFS module and Heketi.

### DIFF
--- a/OLCNE/.env
+++ b/OLCNE/.env
@@ -11,6 +11,9 @@
 # Verbose console
 # VERBOSE=false
 
+# Set the VM provider host-only / private network subnet
+# SUBNET=192.168.99
+
 # Set vCPU count and memory for the VMs (2 vCPU/2GB memory minimum for Master node) (3GB minimum required for Istio)
 # OPERATOR_CPUS=1
 # OPERATOR_MEMORY=1024

--- a/OLCNE/.gitignore
+++ b/OLCNE/.gitignore
@@ -2,4 +2,9 @@
 admin.conf
 local
 id_rsa*
+known_hosts*
 *.swp
+heketi.json*
+topology-olcne.json*
+hyperconverged.yaml*
+ignore-systemd-session-slice.conf*

--- a/OLCNE/README.md
+++ b/OLCNE/README.md
@@ -20,8 +20,9 @@ Native Environment which deploys Kubernetes 1.21.6 configured to use
 the CRI-O runtime interface. Two runtime engines are installed, runc and
 Kata Containers.
 
-You may optionally enable the deployment of the Helm and Istio modules. Note
-that enabling the Istio module will automatically enable the Helm module.
+You may optionally enable the deployment of the Helm, Istio or Gluster modules.
+Note that enabling the Istio or Gluster module will automatically enable the Helm
+module.
 
 _Note:_ Kata Containers requires Intel hardware virtualization support and
 will not work in a VirtualBox guest until nested virtualization support is
@@ -58,7 +59,7 @@ to the Dashboard from a browser on your Vagrant host, you will need to set
 To access the Kubernetes Dashboard, remember to use `localhost` or `127.0.0.1`
 in the URL, i.e. <http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/>.
 
-## About the Vagrantfile
+## About the `Vagrantfile`
 
 The VMs communicate via a private network:
 
@@ -68,14 +69,14 @@ The VMs communicate via a private network:
 
 ## Configuration
 
-The Vagrantfile can be used _as-is_; there are a couple of parameters you
+The `Vagrantfile` can be used _as-is_; there are a couple of parameters you
 can set to tailor the installation to your needs.
 
 ### How to configure
 
 There are several ways to set parameters:
 
-1. Update the Vagrantfile. This is straightforward; the downside is that you
+1. Update the `Vagrantfile`. This is straightforward; the downside is that you
 will lose changes when you update this repository.
 1. Use environment variables. Might be difficult to remember the parameters
 used when the VM was instantiated.
@@ -93,34 +94,40 @@ Parameters are considered in the following order (first one wins):
 is installed)
 1. `.env` (if [vagrant-env](https://github.com/gosuri/vagrant-env) plugin
 is installed)
-1. Vagrantfile definitions
+1. `Vagrantfile` definitions
 
 ### VM parameters
 
 - `VERBOSE` (default: `false`): verbose output during VM deployment.
-- `WORKER_CPUS` (default: 1):  Provision Worker Node with 1 vCPU.
-- `WORKER_MEMORY` (default: 1024): Provision Worker Node with 1GB memory.
-- `MASTER_CPUS` (default: 2): At least 2 vCPUS are required for Master Nodes.
-- `MASTER_MEMORY` (default: 2048): At least 1700MB are required for Master Nodes.
-- `OPERATOR_CPUS` (default: 1): Only applicable if `STANDALONE_OPERATOR=true`.
-- `OPERATOR_MEMORY` (default: 1024): Only applicable if `STANDALONE_OPERATOR=true`.
+- `WORKER_CPUS` (default: `1`):  Provision Worker Node with 1 vCPU.
+- `WORKER_MEMORY` (default: `1024`): Provision Worker Node with 1GB memory.
+- `MASTER_CPUS` (default: `2`): At least 2 vCPUS are required for Master Nodes.
+- `MASTER_MEMORY` (default: `2048`): At least 1700MB are required for Master Nodes.
+- `OPERATOR_CPUS` (default: `1`): Only applicable if `STANDALONE_OPERATOR=true` or `MULTI_MASTER=true`.
+- `OPERATOR_MEMORY` (default: `1024`): Only applicable if `STANDALONE_OPERATOR=true` or `MULTI_MASTER=true`.
 - `VB_GROUP` (default: `OLCNE`): group all VirtualBox VMs under this label.
-- `EXTRA_DISK` (default: `false`): Creates an extra disk (/dev/sdb) that can be used for GlusterFS for Kubernetes Persistent Volumes
+- `EXTRA_DISK` (default: `false`): Creates an extra disk (/dev/sdb) on Worker nodes that can be used for GlusterFS for Kubernetes Persistent Volumes
 
 ### Cluster parameters
 
-- `STANDALONE_OPERATOR` (default: `false`): create a separate VM for the
-operator node -- default is to install the operator components on the (first)
-master node.
+- `STANDALONE_OPERATOR` (default: `false` unless `MULTI_MASTER=true`): create
+a separate VM for the operator node -- default is to install the operator
+components on the (first) master node.
 - `MULTI_MASTER` (default: `false`): multi-master setup. Deploy 3 masters in
 HA mode.
-- `NB_WORKERS` (default: 2): number of worker nodes to provision.
+- `NB_WORKERS` (default: `2`): number of worker nodes to provision.
 At least one worker node is required.
 - `BIND_PROXY` (default: `false`): bind the kubectl proxy port (8001) from the
 (first) master to the Vagrant host. This is required if you want to access the
 Kubernetes Dashboard from a browser on your host.
 __Note__: you only need this if you want to expose the kubectl proxy to other
 hosts in your network.
+- `DEPLOY_HELM` (default: `false`): deploys the Helm module.
+- `DEPLOY_ISTIO` (default: `false`): deploys the Istio and Helm modules.
+- `DEPLOY_GLUSTER` (default: `false`): deploys the Gluster and Helm modules.
+__Note__: if `NB_WORKERS` is less than `3`, the `hyperconverged` `storageclass`
+is patched to adjust the numbers of Gluster replicas accordingly.
+__Note__: This provisioning script also installs Heketi on the operator node.
 
 ### Repositories
 
@@ -133,7 +140,7 @@ registry for Oracle Linux Cloud Native Environment images.
 
 For performance reasons, we recommend using the closest Oracle Container Registry mirror to your region. A list of available regions can be found on the [Regions and Availability Domains](https://docs.cloud.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm) page of the Oracle Cloud Infrastructure documentation.
 
-To specify an Oracle Container Registry mirror, either edit the Vagrantfile or install the vagrant-env plugin and create a .env.local file that specifies the mirror.
+To specify an Oracle Container Registry mirror, either edit the `Vagrantfile` or install the vagrant-env plugin and create a .env.local file that specifies the mirror.
 
 The following syntax can be used to specify a mirror:
 
@@ -150,11 +157,13 @@ Mainly used for development.
 
 - The following parameters can be set to use specific component version:
 `OLCNE_VERSION`, `NGINX_IMAGE`.
-- `NB_MASTERS` (default: none): override number of masters to deploy.
+- `NB_MASTERS` (default: none): override number of masters to deploy. Requires `MULTI_MASTER=true` to function properly.
+- `SUBNET` (default: `192.168.99`): Set the VM provider host-only / private network subnet.
+- `UPDATE_OS` (default: false): Runs `dnf -y update` and reboots the VM.
 
 ## Optional plugins
 
-When installed, this Vagrantfile will make use of the following third party Vagrant plugins:
+When installed, this `Vagrantfile` will make use of the following third party Vagrant plugins:
 
 - [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
 variables from .env files;

--- a/OLCNE/Vagrantfile
+++ b/OLCNE/Vagrantfile
@@ -15,10 +15,11 @@
 
 # This Vagrantfile creates an Oracle Linux Cloud Native Environment and
 # deploys the Kubernetes module to the master and worker nodes.
-# VMs communicate via a private network:
-#   - Operator: 192.168.99.100         (Optional, none by default)
-#   - Master i: 192.168.99.(100+i)     (1 by default, 3 in HA mode)
-#   - Worker i: 192.168.99.(110+i)     (2 by default)
+# VMs communicate via a private network using subnet 192.168.99.* (by default):
+#   - HA Master IP: 192.168.99.99          (Virtual IP, when in HA mode)
+#   - Operator    : 192.168.99.100         (Optional, none by default)
+#   - Master i    : 192.168.99.(100+i)     (1 by default, 3 in HA mode)
+#   - Worker i    : 192.168.99.(110+i)     (2 by default)
 #
 # Optional plugins:
 #     vagrant-hosts (maintains /etc/hosts for the VMs)
@@ -46,6 +47,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.env.load(".env.local", ".env") # enable the plugin
   end
 
+  # Default Private Network Subnet
+  SUBNET = default_s('SUBNET', '192.168.99')
+  
   # vCPUS and Memory for the VMs
   OPERATOR_CPUS = default_i('OPERATOR_CPUS', 1)
   OPERATOR_MEMORY = default_i("OPERATOR_MEMORY", 1024)
@@ -104,8 +108,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Deploy Istio?
   DEPLOY_ISTIO = default_b('DEPLOY_ISTIO', false)
 
+  # Deploy Gluster?
+  DEPLOY_GLUSTER = default_b('DEPLOY_GLUSTER', false)
+
   # Helm is required to deploy Istio otherwise it's optional
-  if DEPLOY_ISTIO
+  if DEPLOY_ISTIO or DEPLOY_GLUSTER
     DEPLOY_HELM = true
   else
     DEPLOY_HELM = default_b('DEPLOY_HELM', false)
@@ -113,6 +120,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   HELM_MODULE_NAME = default_s('HELM_MODULE_NAME', 'olcne-helm')
   ISTIO_MODULE_NAME = default_s('ISTIO_MODULE_NAME', 'olcne-istio')
+  GLUSTER_MODULE_NAME = default_s('GLUSTER_MODULE_NAME', 'olcne-gluster')
 
   # Use specific component version (mainly used for development)
   NGINX_IMAGE = default_s('NGINX_IMAGE', 'nginx:1.17.7')
@@ -161,6 +169,8 @@ def provision_vm(vm, vm_args)
   args.push("--helm-module-name", HELM_MODULE_NAME) if DEPLOY_HELM
   args.push("--with-istio") if DEPLOY_ISTIO
   args.push("--istio-module-name", ISTIO_MODULE_NAME) if DEPLOY_ISTIO
+  args.push("--with-gluster") if DEPLOY_GLUSTER
+  args.push("--gluster-module-name", GLUSTER_MODULE_NAME) if DEPLOY_GLUSTER
   args.push("--registry-olcne", REGISTRY_OLCNE) if REGISTRY_OLCNE
   args.push("--verbose") if VERBOSE
   vm.provision "shell",
@@ -216,15 +226,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |vb, override|
     vb.customize ["modifyvm", :id, "--groups", "/" + VB_GROUP]
     vb.customize ["modifyvm", :id, "--nested-hw-virt", "on"]
-    if EXTRA_DISK
-      override.vm.disk :disk, size: '16GB', name: 'extra_disk'
-    end
   end
   config.vm.provider :libvirt do |lv|
     lv.nested = true
-    if EXTRA_DISK
-      lv.storage :file, :size => '16G', :type => 'qcow2'
-    end
   end
 
   # Workers provisioning
@@ -233,7 +237,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.define "worker#{i}" do |worker|
       worker.vm.hostname = "worker#{i}.vagrant.vm"
       ip = 110 + i
-      ip_addr = "192.168.99.#{ip}"
+      ip_addr = "#{SUBNET}.#{ip}"
       workers += "#{ip_addr},"
       worker.vm.network :private_network, ip: ip_addr
       if Vagrant.has_plugin?("vagrant-hosts")
@@ -242,10 +246,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       worker.vm.provider "virtualbox" do |vb, override|
         vb.memory = WORKER_MEMORY
         vb.cpus = WORKER_CPUS
+        if EXTRA_DISK
+          override.vm.disk :disk, size: '16GB', name: 'extra_disk'
+        end
       end
       config.vm.provider :libvirt do |lv|
         lv.memory = WORKER_MEMORY
         lv.cpus = WORKER_CPUS
+        if EXTRA_DISK
+          lv.storage :file, :size => '16G', :type => 'qcow2'
+        end
       end
       # Update OS if UPDATE_OS=true
       update_os(worker.vm)
@@ -260,7 +270,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.define "master#{i}" do |master|
       master.vm.hostname = "master#{i}.vagrant.vm"
       ip = 100 + i
-      ip_addr = "192.168.99.#{ip}"
+      ip_addr = "#{SUBNET}.#{ip}"
       masters += "#{ip_addr},"
       master.vm.network :private_network, ip: ip_addr
       if Vagrant.has_plugin?("vagrant-hosts")
@@ -295,7 +305,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if STANDALONE_OPERATOR
     config.vm.define "operator" do |operator|
       operator.vm.hostname = "operator.vagrant.vm"
-      operator.vm.network :private_network, ip: "192.168.99.100"
+      operator.vm.network :private_network, ip: "#{SUBNET}.100"
       if Vagrant.has_plugin?("vagrant-hosts")
         operator.vm.provision :hosts, :sync_hosts => true, :add_localhost_hostnames => false
       end
@@ -311,6 +321,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       update_os(operator.vm)
       # Provisioning: Operator Node
       args = ["--operator"]
+      args.push("--subnet", SUBNET)
       args.push("--workers", workers.chop)
       args.push("--masters", masters.chop)
       args.push("--nginx-image", NGINX_IMAGE)

--- a/OLCNE/scripts/provision.sh
+++ b/OLCNE/scripts/provision.sh
@@ -79,8 +79,8 @@ msg() {
 parse_args() {
   OLCNE_CLUSTER_NAME='' OLCNE_ENV_NAME='' OLCNE_DEV=0 OLCNE_VERSION='' REGISTRY_OLCNE=''
   OPERATOR=0 MULTI_MASTER=0 MASTER=0 MASTERS='' WORKER=0 WORKERS=''
-  VERBOSE=0 EXTRA_REPO='' NGINX_IMAGE=''
-  DEPLOY_HELM=0 HELM_MODULE_NAME='' DEPLOY_ISTIO=0 ISTIO_MODULE_NAME=''
+  VERBOSE=0 SUBNET='' EXTRA_REPO='' NGINX_IMAGE=''
+  DEPLOY_HELM=0 HELM_MODULE_NAME='' DEPLOY_ISTIO=0 ISTIO_MODULE_NAME='' DEPLOY_GLUSTER=0 GLUSTER_MODULE_NAME=''
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -185,6 +185,27 @@ parse_args() {
         ISTIO_MODULE_NAME="$2"
         shift; shift
         ;;
+      "--with-gluster")
+        DEPLOY_HELM=1
+        DEPLOY_GLUSTER=1
+        shift
+        ;;
+      "--gluster-module-name")
+        if [[ $# -lt 2 ]]; then
+          echo "Missing parameter for --gluster-module-name" >&2
+	        exit 1
+        fi
+        GLUSTER_MODULE_NAME="$2"
+        shift; shift
+        ;;
+      "--subnet")
+        if [[ $# -lt 2 ]]; then
+          echo "Missing parameter for --subnet" >&2
+          exit 1
+        fi
+        SUBNET="$2"
+        shift; shift;
+        ;;
       "--verbose")
         VERBOSE=1
         shift
@@ -199,7 +220,7 @@ parse_args() {
   readonly OLCNE_CLUSTER_NAME OLCNE_ENV_NAME OLCNE_DEV REGISTRY_OLCNE
   readonly OPERATOR MULTI_MASTER MASTER MASTERS WORKER WORKERS
   readonly VERBOSE EXTRA_REPO NGINX_IMAGE
-  readonly DEPLOY_HELM HELM_MODULE_NAME DEPLOY_ISTIO ISTIO_MODULE_NAME
+  readonly DEPLOY_HELM HELM_MODULE_NAME DEPLOY_ISTIO ISTIO_MODULE_NAME DEPLOY_GLUSTER GLUSTER_MODULE_NAME
 }
 
 #######################################
@@ -217,7 +238,7 @@ setup_repos() {
 
   # Add OLCNE release package
   echo_do sudo dnf install -y oracle-olcne-release-el8
-  echo_do sudo dnf config-manager --enable ol8_olcne14 ol8_addons ol8_baseos_latest ol8_UEKR6
+  echo_do sudo dnf config-manager --enable ol8_olcne14 ol8_baseos_latest ol8_appstream ol8_addons ol8_UEKR6
   echo_do sudo dnf config-manager --disable ol8_olcne12 ol8_olcne13
 
   # Optional extra repo
@@ -238,8 +259,7 @@ setup_repos() {
 #######################################
 clean_networking() {
   msg "Removing extra NetworkManager connection"
-
-  sudo nmcli con del "Wired connection 1"
+  nmcli -f GENERAL.STATE con show "Wired connection 1" && sudo nmcli con del "Wired connection 1"
 
 }
 
@@ -254,17 +274,25 @@ clean_networking() {
 #######################################
 requirements() {
   msg "Fulfil requirements"
-  # Swap
+  # Disable Swap
   echo_do sudo swapoff -a
   echo_do sudo sed -i "'/ swap /d'" /etc/fstab
 
-  # Bridge filtering
+  # Enable transparent masquerading VxLAN
   echo_do sudo modprobe br_netfilter
   echo_do sudo sh -c "'echo br_netfilter > /etc/modules-load.d/br_netfilter.conf'"
 
+  # Bridge Tunable Parameters
+  cat <<-EOF | sudo tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+net.ipv4.ip_forward = 1
+EOF
+  echo_do sudo /sbin/sysctl -p /etc/sysctl.d/k8s.conf
+  
   # Enable & start firewalld; add eth0 to the public zone
   echo_do sudo systemctl enable --now firewalld
-  echo_do sudo firewall-cmd --permanent --zone=public --add-interface=eth0
+  echo_do sudo firewall-cmd --zone=public --add-interface=eth0 --permanent
 }
 
 #######################################
@@ -324,9 +352,59 @@ install_packages() {
     # Software load balancer firewall rules
     echo_do sudo firewall-cmd --add-port=6444/tcp --permanent
     echo_do sudo firewall-cmd --add-protocol=vrrp --permanent
-
   fi
 
+  if [[ ${DEPLOY_GLUSTER} == 1 ]]; then
+    if [[ ${WORKER} == 1 ]]; then
+      msg "Installing the GlusterFS Server on Worker node"
+      echo_do sudo dnf install -y oracle-gluster-release-el8
+      echo_do sudo dnf config-manager --enable ol8_gluster_appstream
+      echo_do sudo dnf module enable -y glusterfs
+      echo_do sudo dnf install -y @glusterfs/server
+      # Enable TLS...
+      echo_do sudo systemctl enable --now glusterd.service
+      echo_do sudo firewall-cmd --permanent --add-service=glusterfs
+    fi
+
+    if [[ ${OPERATOR} == 1 ]]; then
+      msg "Installing the Heketi Server & CLI on Operator node"
+      echo_do sudo dnf install -y oracle-gluster-release-el8
+      echo_do sudo dnf config-manager --enable ol8_gluster_appstream
+      echo_do sudo dnf module enable -y glusterfs
+      echo_do sudo dnf install -y heketi heketi-client
+      if [[ ${MASTER} == 0 ]]; then
+	# Standalone operator
+	echo_do sudo firewall-cmd --add-port=8080/tcp --permanent
+      fi
+      msg "Modifying the default /etc/heketi/heketi.json onto /vagrant/heketi.json"
+      echo_do sudo dnf install -y jq
+      contents="$(jq '.use_auth=true|.jwt.admin.key="secret"|.glusterfs.executor="ssh"|.glusterfs.sshexec.keyfile="/etc/heketi/vagrant_key"|.glusterfs.sshexec.user="vagrant"|.glusterfs.sshexec.sudo=true|del(.glusterfs.sshexec.port)|del(.glusterfs.sshexec.fstab)|.glusterfs.loglevel="info"' /etc/heketi/heketi.json)" && echo -E "${contents}" > /vagrant/heketi.json
+      echo_do sudo cp /vagrant/heketi.json /etc/heketi/heketi.json
+      echo_do rm -f /vagrant/heketi.json
+      # SSH Key *MUST* be in PEM format! Heketi would reject it otherwise.
+      msg "Copying the Vagrant SSH Key. Must be in PEM format!"
+      echo_do sudo cp /vagrant/id_rsa /etc/heketi/vagrant_key
+      # Fix default permission which exposes the secret /etc/heketi/heketi.json
+      echo_do sudo chmod 0600 /etc/heketi/vagrant_key /etc/heketi/heketi.json
+      echo_do sudo chown -R heketi: /etc/heketi
+      # Enable Heketi
+      echo_do sudo systemctl enable --now heketi.service
+      # Test Heketi
+      msg "Waiting to Heketi service to become ready"
+      echo_do curl --retry-connrefused --retry 10 --retry-delay 5 127.0.0.1:8080/hello
+      # Heketi ready
+      msg "Creating Gluster Topology file /etc/heketi/topology-olcne.json"
+      # https://github.com/heketi/heketi/blob/master/docs/admin/topology.md
+      jq -R '{clusters:[{nodes:(./","|map({node:{hostnames:{manage:[.],storage:[.]},zone:1},devices:[{name:"/dev/sdb",destroydata:false}]}))}]}' <<< "${WORKERS}" > /vagrant/topology-olcne.json
+      echo_do sudo cp /vagrant/topology-olcne.json /etc/heketi/topology-olcne.json
+      echo_do sudo chown heketi: /etc/heketi/topology-olcne.json
+      msg "Loading Gluster Cluster Topology with Heketi"
+      # export HEKETI_CLI_USER=admin; export HEKTI_CLI_KEY=secret
+      echo_do heketi-cli --user=admin --secret=secret topology load --json=/etc/heketi/topology-olcne.json
+      echo_do rm -f /vagrant/topology-olcne.json
+    fi
+  fi
+  
   # Reload firewalld
   echo_do sudo firewall-cmd --reload
 }
@@ -344,32 +422,48 @@ passwordless_ssh() {
   msg "Allow passwordless ssh between VMs"
   # Generate common key
   if [[ ! -f /vagrant/id_rsa ]]; then
-    msg "Generating shared SSH keypair"
-    echo_do ssh-keygen -t rsa -f /vagrant/id_rsa -q -N "''" -C 'vagrant@olcne'
+    msg "Generating shared SSH keypair in PEM format"
+    echo_do ssh-keygen -m PEM -t rsa -f /vagrant/id_rsa -q -N "''" -C "'vagrant@olcne'"
   fi
+  # Generate known_hosts
+  if [[ ! -f /vagrant/known_hosts ]]; then
+    msg "Generating shared SSH Known Hosts file"
+    echo_do touch /vagrant/known_hosts
+  fi  
   # Install private key
   #echo_do mkdir -p /root/.ssh
   echo_do cp /vagrant/id_rsa ~/.ssh
   echo_do cp /vagrant/id_rsa.pub ~/.ssh
   # Authorise passwordless ssh
   #echo_do cp /vagrant/id_rsa.pub /root/.ssh/authorized_keys
-  echo_do sh -c "'cat /vagrant/id_rsa.pub >> ~/.ssh/authorized_keys'"
+  #echo_do sh -c "'cat /vagrant/id_rsa.pub >> ~/.ssh/authorized_keys'"
+  echo_do "cat /vagrant/id_rsa.pub >> ~/.ssh/authorized_keys"
   # Don't do host checking
-  cat > ~/.ssh/config <<-EOF
-	Host operator* master* worker* 192.168.99.*
-	  StrictHostKeyChecking no
-	  UserKnownHostsFile /dev/null
-	  LogLevel FATAL
-	EOF
+  # cat > ~/.ssh/config <<-EOF
+  # 	Host operator* master* worker* 192.168.99.*
+  # 	  StrictHostKeyChecking no
+  # 	  UserKnownHostsFile /dev/null
+  # 	  LogLevel FATAL
+  # 	EOF
   # Set permissions
   echo_do chmod 0700 ~/.ssh
   echo_do chmod 0600 ~/.ssh/authorized_keys ~/.ssh/id_rsa
   echo_do chmod 0644 ~/.ssh/authorized_keys ~/.ssh/id_rsa.pub
-  echo_do chmod 0644 ~/.ssh/authorized_keys ~/.ssh/config
+  #echo_do chmod 0644 ~/.ssh/authorized_keys ~/.ssh/config
+  # SSH Host Keys. Should really use ssh-keyscan -t ecdsa,ed25519
+  echo_do eval 'echo "`hostname -s`,`hostname -f`,`hostname -i` `cat /etc/ssh/ssh_host_ed25519_key.pub`" >> /vagrant/known_hosts'
   # Last node removes the key
   if [[ ${OPERATOR} == 1 ]]; then
     msg "Removing the shared SSH keypair"
     echo_do rm /vagrant/id_rsa /vagrant/id_rsa.pub
+
+    msg "Copying SSH Host Keys"
+    echo_do sudo cp /vagrant/known_hosts /etc/ssh/ssh_known_hosts
+    for node in ${MASTERS//,/ } ${WORKERS//,/ }; do
+	echo_do ssh "${node}" "sudo cp /vagrant/known_hosts /etc/ssh/ssh_known_hosts"
+    done
+    msg "Removing the shared SSH Known Hosts file"
+    echo_do rm /vagrant/known_hosts
   fi
 }
 
@@ -390,7 +484,7 @@ certificates() {
 
   if [[ ${MASTER} == 0 ]]; then
     # Standalone operator
-    nodes="192.168.99.100,${nodes}"
+    nodes="${SUBNET}.100,${nodes}"
   fi
   echo_do sudo /etc/olcne/gen-certs-helper.sh --nodes "${nodes}"  --cert-dir "${CERT_DIR}"
 
@@ -486,7 +580,7 @@ deploy_kubernetes() {
       --container-registry "${REGISTRY_OLCNE}" \
       --nginx-image "${REGISTRY_OLCNE}/${NGINX_IMAGE}" \
       --pod-network-iface eth1 \
-      --virtual-ip 192.168.99.99 \
+      --virtual-ip "${SUBNET}.99" \
       --master-nodes "${master_nodes}" \
       --worker-nodes "${worker_nodes}" \
       --restrict-service-externalip-ca-cert=${EXTERNALIP_VALIDATION_CERT_DIR}/production/ca.cert \
@@ -511,6 +605,7 @@ deploy_kubernetes() {
 #   OLCNE_CLUSTER_NAME OLCNE_ENV_NAME
 #   DEPLOY_HELM HELM_MODULE_NAME
 #   DEPLOY_ISTIO ISTIO_MODULE_NAME
+#   DEPLOY_GLUSTER GLUSTER_MODULE_NAME
 #   REGISTRY_OLCNE
 # Arguments:
 #   None
@@ -570,6 +665,37 @@ deploy_modules() {
     echo_do olcnectl module install \
       --environment-name "${OLCNE_ENV_NAME}" \
       --name "${ISTIO_MODULE_NAME}"
+  fi
+
+  # Gluster module (using Heketi)
+  if [[ ${DEPLOY_GLUSTER} == 1 ]]; then
+
+    # Create the Gluster module
+    # using defaults url/user/secret-key: olcnectl module create --module gluster --help
+    msg "Creating the Gluster module: ${GLUSTER_MODULE_NAME}"
+    HEKETI_CLI_SERVER="http://127.0.0.1:8080"
+    if [[ ${MASTER} == 0 ]]; then
+      # Standalone operator
+      HEKETI_CLI_SERVER="http://${SUBNET}.100:8080"
+    fi
+    echo_do olcnectl module create \
+      --environment-name "${OLCNE_ENV_NAME}" \
+      --module gluster \
+      --name "${GLUSTER_MODULE_NAME}" \
+      --gluster-helm-module "${HELM_MODULE_NAME}" \
+      --gluster-server-url "${HEKETI_CLI_SERVER}"
+      
+    # Validate the Gluster module
+    msg "Validating the Gluster module: ${Gluster_MODULE_NAME}"
+    echo_do olcnectl module validate \
+      --environment-name "${OLCNE_ENV_NAME}" \
+      --name "${GLUSTER_MODULE_NAME}"
+
+    # Deploy the Gluster module
+    msg "Deploying the Gluster module: ${GLUSTER_MODULE_NAME} into ${OLCNE_CLUSTER_NAME}"
+    echo_do olcnectl module install \
+      --environment-name "${OLCNE_ENV_NAME}" \
+      --name "${GLUSTER_MODULE_NAME}"
   fi
 
 }
@@ -655,6 +781,53 @@ EOF' \
       \""
     done
   fi
+
+  # Fix: heketi: systemd[1]: /usr/lib/systemd/system/glusterd.service:21: Unknown lvalue 'StartLimitIntervalSec' in section 'Service'
+  if [[ ${DEPLOY_GLUSTER} == 1 ]]; then
+    msg "Removing StartLimitIntervalSec from /usr/lib/systemd/system/glusterd.service on Gluster nodes"
+    for node in ${WORKERS//,/ }; do
+      echo_do ssh "${node}" "\"\
+        sudo sed -i '/^StartLimitIntervalSec=/d' /usr/lib/systemd/system/glusterd.service \
+	&& sudo systemctl daemon-reload \
+        && sudo systemctl restart glusterd.service \
+      \""
+    done
+
+    NB_WORKERS=$(echo ${WORKERS} | awk -F',' '{print NF}')
+    if [[ ${NB_WORKERS} -lt "3" ]]; then
+      # https://kubernetes.io/docs/concepts/storage/storage-classes/#glusterfs
+      # https://github.com/kubernetes/examples/blob/master/staging/persistent-volume-provisioning/README.md
+      volumetype=
+      if [[ ${NB_WORKERS} == "2" ]]; then # 2 replicas
+	  volumetype="replicate:2"
+      elif [[ ${NB_WORKERS} == "1" ]]; then # Distribute volume
+	  volumetype="none"
+      fi      
+      msg "Patching the Kubernetes hyperconverged storageclass volumetype to $volumetype"
+      node=${MASTERS//,*/}
+      # K8s Storage Classes are immutable. Cannot: kubectl patch storageclasses hyperconverged -p '{"Parameters":{"volumetype":"replicate:2"}}'
+      echo_do ssh "${node}" "\"\
+        kubectl get storageclasses hyperconverged -o=yaml | yq w - parameters.volumetype none > /vagrant/hyperconverged.yaml \
+	&& kubectl replace -f /vagrant/hyperconverged.yaml --force \
+	&& rm -f /vagrant/hyperconverged.yaml \
+      \""
+    fi
+  fi
+
+  # Fix: Created slice, Starting Session # https://access.redhat.com/solutions/1564823
+  msg "Create discard filter to suppress user / session log entries in /var/log/messages"
+  nodes="${MASTERS},${WORKERS}"
+  if [[ ${MASTER} == 0 ]]; then
+    nodes="${SUBNET}.100,${nodes}"
+  fi
+  echo 'if $programname == "systemd" and ($msg contains "Starting Session" or $msg contains "Started Session" or $msg contains "Created slice" or $msg contains "Starting user-" or $msg contains "Starting User Slice of" or $msg contains "Removed session" or $msg contains "Removed slice User Slice of" or $msg contains "Stopping User Slice of") then stop' > /vagrant/ignore-systemd-session-slice.conf
+  for node in ${nodes//,/ }; do
+    echo_do ssh "${node}" "\"\
+      sudo cp /vagrant/ignore-systemd-session-slice.conf /etc/rsyslog.d/ignore-systemd-session-slice.conf \
+      && sudo systemctl restart rsyslog \
+      \""
+  done
+  echo_do rm -f /vagrant/ignore-systemd-session-slice.conf
   
 }
 


### PR DESCRIPTION
Signed-off-by: Hussam Qasem <hqasem@tyeb.com>

* Create Vagrant SSH Key in PEM format to be used by Heketi
* Create SSH Known Hosts to enable Host Ket checking
* Enable `ol8_appstream` required by GlusterFS
* Modify `Vagrantfile` to provision `EXTRA_DISK` on Worker nodes only.
* If `DEPLOY_GLUSTER=true` :
  * Install GlusterFS server on Worker nodes.
  * Install Heketi on `OPERATOR` node using default values for port, admin-user, secret-key.
  * If `NB_WORKERS` is less than `3`, patch the `hyperconverged` Kubernetes `storageclass` `volumetype`.
* Allow to configure host-only Subnet (my Virtualbox is stuck on `192.168.56.*` and I cannot change it!)
* Update the `README.md` documentation accordingly.