### PR TITLE
426 fixes

### DIFF
--- a/OLCNE/.env
+++ b/OLCNE/.env
@@ -1,7 +1,7 @@
 # -*- mode: shell-script -*-
 # vi: set ft=shell :
 
-# Oracle Linux Cloud Native Environment configuration file
+# Oracle Cloud Native Environment configuration file
 #
 # Requires vagrant-env plugin
 #
@@ -26,7 +26,7 @@
 # WORKER_MEMORY=1024
 
 # Group VirtualBox containers
-# VB_GROUP="OLCNE"
+# VB_GROUP="OCNE"
 
 # Create a separate instance for the operator node?
 # The default is to install the Platform API Server and CLI tool on
@@ -50,32 +50,32 @@
 # Additional yum channel to consider (e.g. local repo)
 # YUM_REPO=
 
-# Add OLCNE developer channel
-# OLCNE_DEV=false
+# Add OCNE developer channel
+# OCNE_DEV=false
 
-# Container registry for Oracle Linux Cloud Native Environment images
+# Container registry for Oracle Cloud Native Environment images
 # You can use registry mirrors in a region close to you.
 # Check the README.md file for more details.
-# REGISTRY_OLCNE='container-registry.oracle.com/olcne'
+# REGISTRY_OCNE='container-registry.oracle.com/olcne'
 
 # Use specific NGINX version (mainly used for development)
 # NGINX_IMAGE=
 
 # Environment and cluster names
-# OLCNE_ENV_NAME="olcne-env"
-# OLCNE_CLUSTER_NAME="olcne-cluster"
+# OCNE_ENV_NAME="ocne-env"
+# OCNE_CLUSTER_NAME="ocne-cluster"
 
 # Deploy the Helm module?
 # DEPLOY_HELM=false
-# HELM_MODULE_NAME="olcne-helm"
+# HELM_MODULE_NAME="ocne-helm"
 
 # Deploy the Istio module? Requires the Helm module and will set DEPLOY_HELM to 1 if not set.
 # DEPLOY_ISTIO=false
-# ISTIO_MODULE_NAME="olcne-istio"
+# ISTIO_MODULE_NAME="ocne-istio"
 
 # Deploy the Gluster module? Requires the Helm module and will set DEPLOY_HELM to 1 if not set.
 # DEPLOY_GLUSTER=false
-# GLUSTER_MODULE_NAME="olcne-gluster"
+# GLUSTER_MODULE_NAME="ocne-gluster"
 
 # Override number of masters to deploy
 # This should not be changed -- for development purpose

--- a/OLCNE/README.md
+++ b/OLCNE/README.md
@@ -1,21 +1,21 @@
-# Vagrant project to set up Oracle Linux Cloud Native Environment on Oracle Linux 8
+# Vagrant project to set up Oracle Cloud Native Environment on Oracle Linux 8
 
 This Vagrant project will deploy and configure the following components:
 
 - One or more master nodes (one by default, 3 in HA mode)
 - One or more worker nodes (2 by default)
-- An optional operator node for the Oracle Linux Cloud Native Environment
+- An optional operator node for the Oracle Cloud Native Environment
 Platform API Server and Platform CLI tool (default is to install these
 components on the first master node)
 
 If you enable multiple master nodes, an operator node is automatically deployed
 to provide egress routing for the cluster.
 
-All master and worker nodes will have the Oracle Linux Cloud Native
+All master and worker nodes will have the Oracle Cloud Native
 Environment Platform Agent installed and configured to communicate with the
 Platform API Server on the operator node.
 
-The installation includes the Kubernetes module for Oracle Linux Cloud
+The installation includes the Kubernetes module for Oracle Cloud
 Native Environment which deploys Kubernetes 1.21.6 configured to use
 the CRI-O runtime interface. Two runtime engines are installed, runc and
 Kata Containers.
@@ -40,7 +40,7 @@ makes configuration much easier
 1. Change into the `vagrant-projects/OLCNE` directory
 1. Run `vagrant up`
 
-Your Oracle Linux Cloud Native Environment is ready!
+Your Oracle Cloud Native Environment is ready!
 
 From any master node (e.g. master1) you can check the status of the cluster (as
 the `vagrant` user). E.g.:
@@ -134,10 +134,10 @@ __Note__: This provisioning script also installs Heketi on the operator node.
 
 - `YUM_REPO` (default: none): additional yum repository to consider
 (e.g. local repo)
-- `OLCNE_DEV` (default: `false`): whether to enable the Oracle Linux Cloud
+- `OLCNE_DEV` (default: `false`): whether to enable the Oracle Cloud
 Native Environment developer channel.
 - `REGISTRY_OLCNE` (default: `container-registry.oracle.com/olcne`): Container
-registry for Oracle Linux Cloud Native Environment images.
+registry for Oracle Cloud Native Environment images.
 
 For performance reasons, we recommend using the closest Oracle Container Registry mirror to your region. A list of available regions can be found on the [Regions and Availability Domains](https://docs.cloud.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm) page of the Oracle Cloud Infrastructure documentation.
 
@@ -182,9 +182,9 @@ vagrant plugin install <name>...
 
 ## Product Documentation
 
-- [Oracle Linux Cloud Native Environment: Getting Started](https://docs.oracle.com/en/operating-systems/olcne/start/index.html)
-- [Oracle Linux Cloud Native Environment: Using Container Orchestration](https://docs.oracle.com/en/operating-systems/olcne/orchestration/index.html)
-- [Oracle Linux Cloud Native Environment: Using Container Runtimes](https://docs.oracle.com/en/operating-systems/olcne/runtimes/index.html)
+- [Oracle Cloud Native Environment: Getting Started](https://docs.oracle.com/en/operating-systems/olcne/start/index.html)
+- [Oracle Cloud Native Environment: Using Container Orchestration](https://docs.oracle.com/en/operating-systems/olcne/orchestration/index.html)
+- [Oracle Cloud Native Environment: Using Container Runtimes](https://docs.oracle.com/en/operating-systems/olcne/runtimes/index.html)
 
 ## Feedback
 

--- a/OLCNE/README.md
+++ b/OLCNE/README.md
@@ -106,7 +106,7 @@ is installed)
 - `MASTER_MEMORY` (default: `2048`): At least 1700MB are required for Master Nodes.
 - `OPERATOR_CPUS` (default: `1`): Only applicable if `STANDALONE_OPERATOR=true` or `MULTI_MASTER=true`.
 - `OPERATOR_MEMORY` (default: `1024`): Only applicable if `STANDALONE_OPERATOR=true` or `MULTI_MASTER=true`.
-- `VB_GROUP` (default: `OLCNE`): group all VirtualBox VMs under this label.
+- `VB_GROUP` (default: `OCNE`): group all VirtualBox VMs under this label.
 - `EXTRA_DISK` (default: `false`): Creates an extra disk (`/dev/sdb`) on Worker nodes that can be used for GlusterFS for Kubernetes Persistent Volumes
 
 ### Cluster parameters
@@ -134,9 +134,9 @@ __Note__: This provisioning script also installs Heketi on the operator node.
 
 - `YUM_REPO` (default: none): additional yum repository to consider
 (e.g. local repo)
-- `OLCNE_DEV` (default: `false`): whether to enable the Oracle Cloud
+- `OCNE_DEV` (default: `false`): whether to enable the Oracle Cloud
 Native Environment developer channel.
-- `REGISTRY_OLCNE` (default: `container-registry.oracle.com/olcne`): Container
+- `REGISTRY_OCNE` (default: `container-registry.oracle.com/olcne`): Container
 registry for Oracle Cloud Native Environment images.
 
 For performance reasons, we recommend using the closest Oracle Container Registry mirror to your region. A list of available regions can be found on the [Regions and Availability Domains](https://docs.cloud.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm) page of the Oracle Cloud Infrastructure documentation.

--- a/OLCNE/Vagrantfile
+++ b/OLCNE/Vagrantfile
@@ -1,11 +1,11 @@
 #
-# Vagrantfile for Oracle Linux Cloud Native Environment
+# Vagrantfile for Oracle Cloud Native Environment
 #
 # Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl.
 #
-# Description: Deploys an Oracle Linux Cloud Native Environment
+# Description: Deploys an Oracle Cloud Native Environment
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
@@ -13,7 +13,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# This Vagrantfile creates an Oracle Linux Cloud Native Environment and
+# This Vagrantfile creates an Oracle Cloud Native Environment and
 # deploys the Kubernetes module to the master and worker nodes.
 # VMs communicate via a private network using subnet 192.168.99.* (by default):
 #   - HA Master IP: 192.168.99.99          (Virtual IP, when in HA mode)
@@ -59,12 +59,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   WORKER_MEMORY = default_i("WORKER_MEMORY", 1024)
 
   # Group VirtualBox containers
-  VB_GROUP = default_s("VB_GROUP", "OLCNE")
+  VB_GROUP = default_s("VB_GROUP", "OCNE")
 
   # Multi-master setup. Deploy 3 masters in HA mode.
   MULTI_MASTER = default_b('MULTI_MASTER', false)
 
-  # Separate operator node for the Oracle Linux Cloud Native Environment
+  # Separate operator node for the Oracle Cloud Native Environment
   # Platform API Server and Platform Agent (default is to install the
   # components on the (first) master node
   #
@@ -93,17 +93,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Additional yum channel to consider (e.g. local repo)
   YUM_REPO = default_s('YUM_REPO', '')
 
-  # Add Oracle Linux Cloud Native Environment developer channel
-  OLCNE_DEV = default_b('OLCNE_DEV', false)
+  # Add Oracle Cloud Native Environment developer channel
+  OCNE_DEV = default_b('OCNE_DEV', false)
 
-  # Set the default OLCNE_ENV_NAME and OLCNE_CLUSTER_NAMEs
-  OLCNE_ENV_NAME = default_s('OLCNE_ENV_NAME', 'olcne-env')
-  OLCNE_CLUSTER_NAME = default_s('OLCNE_CLUSTER_NAME', 'olcne-cluster')
+  # Set the default OCNE_ENV_NAME and OCNE_CLUSTER_NAMEs
+  OCNE_ENV_NAME = default_s('OCNE_ENV_NAME', 'ocne-env')
+  OCNE_CLUSTER_NAME = default_s('OCNE_CLUSTER_NAME', 'ocne-cluster')
 
-  # Container registry for Oracle Linux Cloud Native Environment images
+  # Container registry for Oracle Cloud Native Environment images
   # You can use registry mirrors in a region close to you.
   # Check the README.md file for more details.
-  REGISTRY_OLCNE = default_s('REGISTRY_OLCNE', 'container-registry.oracle.com/olcne')
+  REGISTRY_OCNE = default_s('REGISTRY_OCNE', 'container-registry.oracle.com/olcne')
 
   # Deploy Istio?
   DEPLOY_ISTIO = default_b('DEPLOY_ISTIO', false)
@@ -118,9 +118,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     DEPLOY_HELM = default_b('DEPLOY_HELM', false)
   end
 
-  HELM_MODULE_NAME = default_s('HELM_MODULE_NAME', 'olcne-helm')
-  ISTIO_MODULE_NAME = default_s('ISTIO_MODULE_NAME', 'olcne-istio')
-  GLUSTER_MODULE_NAME = default_s('GLUSTER_MODULE_NAME', 'olcne-gluster')
+  HELM_MODULE_NAME = default_s('HELM_MODULE_NAME', 'ocne-helm')
+  ISTIO_MODULE_NAME = default_s('ISTIO_MODULE_NAME', 'ocne-istio')
+  GLUSTER_MODULE_NAME = default_s('GLUSTER_MODULE_NAME', 'ocne-gluster')
 
   # Use specific component version (mainly used for development)
   NGINX_IMAGE = default_s('NGINX_IMAGE', 'nginx:1.17.7')
@@ -160,18 +160,18 @@ end
 
 def provision_vm(vm, vm_args)
   args = vm_args.clone
-  args.push("--olcne-environment-name", OLCNE_ENV_NAME)
-  args.push("--olcne-cluster-name", OLCNE_CLUSTER_NAME)
+  args.push("--ocne-environment-name", OCNE_ENV_NAME)
+  args.push("--ocne-cluster-name", OCNE_CLUSTER_NAME)
   args.push("--multi-master") if MULTI_MASTER
   args.push("--repo", YUM_REPO) unless YUM_REPO == ""
-  args.push("--olcne-dev") if OLCNE_DEV
+  args.push("--ocne-dev") if OCNE_DEV
   args.push("--with-helm") if DEPLOY_HELM
   args.push("--helm-module-name", HELM_MODULE_NAME) if DEPLOY_HELM
   args.push("--with-istio") if DEPLOY_ISTIO
   args.push("--istio-module-name", ISTIO_MODULE_NAME) if DEPLOY_ISTIO
   args.push("--with-gluster") if DEPLOY_GLUSTER
   args.push("--gluster-module-name", GLUSTER_MODULE_NAME) if DEPLOY_GLUSTER
-  args.push("--registry-olcne", REGISTRY_OLCNE) if REGISTRY_OLCNE
+  args.push("--registry-ocne", REGISTRY_OCNE) if REGISTRY_OCNE
   args.push("--verbose") if VERBOSE
   vm.provision "shell",
     path: "scripts/provision.sh",

--- a/OLCNE/scripts/provision.sh
+++ b/OLCNE/scripts/provision.sh
@@ -723,6 +723,8 @@ fixups() {
       echo 'source <(kubectl completion bash)' >> ~/.bashrc; \
       echo 'alias k=kubectl' >> ~/.bashrc; \
       echo 'complete -F __start_kubectl k' >> ~/.bashrc; \
+      echo 'command -v helm >/dev/null 2>&1 && source <(helm completion bash)' >> ~/.bashrc; \
+      echo 'command -v istioctl >/dev/null 2>&1 && source <(istioctl completion bash)' >> ~/.bashrc; \
       \""
   done
 

--- a/OLCNE/scripts/provision.sh
+++ b/OLCNE/scripts/provision.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 #
-# Provision Oracle Linux Cloud Native Environment nodes
+# Provision Oracle Cloud Native Environment nodes
 #
 # Copyright (c) 2019, 2021 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl.
 #
-# Description: Installs the Oracle Linux Cloud Native Environment packages,
+# Description: Installs the Oracle Cloud Native Environment packages,
 # configures all prerequisites and deploys the Kubernetes module.
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
@@ -68,8 +68,8 @@ msg() {
 # Parse arguments
 # Exit on error.
 # Globals:
-#   OLCNE_DEV OLCNE_VERSION K8S_VERSION MASTER MASTERS WORKER WORKERS
-#   OPERATOR MULTI_MASTER REGISTRY_OLCNE VERBOSE EXTRA_REPO
+#   OCNE_DEV OCNE_VERSION K8S_VERSION MASTER MASTERS WORKER WORKERS
+#   OPERATOR MULTI_MASTER REGISTRY_OCNE VERBOSE EXTRA_REPO
 #   NGINX_IMAGE
 # Arguments:
 #   Command line
@@ -77,7 +77,7 @@ msg() {
 #   None
 #######################################
 parse_args() {
-  OLCNE_CLUSTER_NAME='' OLCNE_ENV_NAME='' OLCNE_DEV=0 OLCNE_VERSION='' REGISTRY_OLCNE=''
+  OCNE_CLUSTER_NAME='' OCNE_ENV_NAME='' OCNE_DEV=0 OCNE_VERSION='' REGISTRY_OCNE=''
   OPERATOR=0 MULTI_MASTER=0 MASTER=0 MASTERS='' WORKER=0 WORKERS=''
   VERBOSE=0 SUBNET='' EXTRA_REPO='' NGINX_IMAGE=''
   DEPLOY_HELM=0 HELM_MODULE_NAME='' DEPLOY_ISTIO=0 ISTIO_MODULE_NAME='' DEPLOY_GLUSTER=0 GLUSTER_MODULE_NAME=''
@@ -100,24 +100,24 @@ parse_args() {
         MULTI_MASTER=1
         shift
         ;;
-      "--olcne-dev")
-        OLCNE_DEV=1
+      "--ocne-dev")
+        OCNE_DEV=1
         shift
         ;;
-      "--olcne-environment-name")
+      "--ocne-environment-name")
         if [[ $# -lt 2 ]]; then
-          echo "Missing parameter for --olcne-environment-name" >&2
+          echo "Missing parameter for --ocne-environment-name" >&2
           exit 1
         fi
-        OLCNE_ENV_NAME="$2"
+        OCNE_ENV_NAME="$2"
         shift; shift;
         ;;
-      "--olcne-cluster-name")
+      "--ocne-cluster-name")
         if [[ $# -lt 2 ]]; then
-          echo "Missing parameter for --olcne-cluster-name" >&2
+          echo "Missing parameter for --ocne-cluster-name" >&2
           exit 1
         fi
-        OLCNE_CLUSTER_NAME="$2"
+        OCNE_CLUSTER_NAME="$2"
         shift; shift;
         ;;
       "--nginx-image")
@@ -136,12 +136,12 @@ parse_args() {
         EXTRA_REPO="$2"
         shift; shift
         ;;
-      "--registry-olcne")
+      "--registry-ocne")
         if [[ $# -lt 2 ]]; then
-          echo "Missing parameter for --registry-olcne" >&2
+          echo "Missing parameter for --registry-ocne" >&2
 	        exit 1
         fi
-        REGISTRY_OLCNE="$2"
+        REGISTRY_OCNE="$2"
         shift; shift
         ;;
       "--masters")
@@ -217,7 +217,7 @@ parse_args() {
     esac
   done
 
-  readonly OLCNE_CLUSTER_NAME OLCNE_ENV_NAME OLCNE_DEV REGISTRY_OLCNE
+  readonly OCNE_CLUSTER_NAME OCNE_ENV_NAME OCNE_DEV REGISTRY_OCNE
   readonly OPERATOR MULTI_MASTER MASTER MASTERS WORKER WORKERS
   readonly VERBOSE EXTRA_REPO NGINX_IMAGE
   readonly DEPLOY_HELM HELM_MODULE_NAME DEPLOY_ISTIO ISTIO_MODULE_NAME DEPLOY_GLUSTER GLUSTER_MODULE_NAME
@@ -227,16 +227,16 @@ parse_args() {
 # Configure repos for the installation
 # Globals:
 #   EXTRA_REPO
-#   OLCNE_DEV
+#   OCNE_DEV
 # Arguments:
 #   None
 # Returns:
 #   None
 #######################################
 setup_repos() {
-  msg "Configure repos for Oracle Linux Cloud Native Environment"
+  msg "Configure repos for Oracle Cloud Native Environment"
 
-  # Add OLCNE release package
+  # Add OCNE release package
   echo_do sudo dnf install -y oracle-olcne-release-el8
   echo_do sudo dnf config-manager --enable ol8_olcne14 ol8_baseos_latest ol8_appstream ol8_addons ol8_UEKR6
   echo_do sudo dnf config-manager --disable ol8_olcne12 ol8_olcne13
@@ -244,8 +244,8 @@ setup_repos() {
   # Optional extra repo
   if [[ -n ${EXTRA_REPO} ]]; then echo_do sudo dnf config-manager --add-repo "${EXTRA_REPO}"; fi
 
-  # Enable OLCNE developer channel
-  if [[ ${OLCNE_DEV} == 1 ]]; then echo_do sudo dnf config-manager --enable ol8_developer_olcne; fi
+  # Enable OCNE developer channel
+  if [[ ${OCNE_DEV} == 1 ]]; then echo_do sudo dnf config-manager --enable ol8_developer_olcne; fi
 }
 
 #######################################
@@ -297,12 +297,12 @@ requirements() {
 
 #######################################
 # Install packages on the node
-# Note: As of OLCNE 1.0.1 kubernetes packages are deployed automatically.
+# Note: As of OCNE 1.0.1 kubernetes packages are deployed automatically.
 # We are still installing them to be able to customize the configuration for
 # the vagrant environment.
 # Globals:
-#   OPERATOR OLCNE_VERSION MASTER WORKER K8S_VERSION MULTI_MASTER
-#   REGISTRY_OLCNE NGINX_IMAGE
+#   OPERATOR OCNE_VERSION MASTER WORKER K8S_VERSION MULTI_MASTER
+#   REGISTRY_OCNE NGINX_IMAGE
 # Arguments:
 #   None
 # Returns:
@@ -311,15 +311,15 @@ requirements() {
 install_packages() {
 
   if [[ ${OPERATOR} == 1 ]]; then
-    msg "Installing the Oracle Linux Cloud Native Environment Platform API Server and Platform CLI tool to the operator node."
-    echo_do sudo dnf install -y olcnectl"${OLCNE_VERSION}" olcne-api-server"${OLCNE_VERSION}" olcne-utils"${OLCNE_VERSION}"
+    msg "Installing the Oracle Cloud Native Environment Platform API Server and Platform CLI tool to the operator node."
+    echo_do sudo dnf install -y olcnectl"${OCNE_VERSION}" olcne-api-server"${OCNE_VERSION}" olcne-utils"${OCNE_VERSION}"
     echo_do sudo systemctl enable olcne-api-server.service
     echo_do sudo firewall-cmd --add-port=8091/tcp --permanent
     echo_do sudo firewall-cmd --add-masquerade --permanent
   fi
   if [[ ${MASTER} == 1 || ${WORKER} == 1 ]]; then
-    msg "Installing the Oracle Linux Cloud Native Environment Platform Agent"
-    echo_do sudo dnf install -y olcne-agent"${OLCNE_VERSION}" olcne-utils"${OLCNE_VERSION}"
+    msg "Installing the Oracle Cloud Native Environment Platform Agent"
+    echo_do sudo dnf install -y olcne-agent"${OCNE_VERSION}" olcne-utils"${OCNE_VERSION}"
     echo_do sudo systemctl enable olcne-agent.service
     if [[ -n ${HTTP_PROXY} ]]; then
       # CRI-O proxies
@@ -344,7 +344,7 @@ install_packages() {
     echo_do sudo dnf install -y bash-completion
     echo_do sudo firewall-cmd --add-port=6443/tcp --permanent
     echo_do sudo firewall-cmd --add-port=8001/tcp --permanent
-    # OLCNE 1.0.1 requires these ports for single master as well
+    # OCNE 1.0.1 requires these ports for single master as well
     echo_do sudo firewall-cmd --add-port=10251/tcp --permanent
     echo_do sudo firewall-cmd --add-port=10252/tcp --permanent
     echo_do sudo firewall-cmd --add-port=2379/tcp --permanent
@@ -407,15 +407,15 @@ install_packages() {
       msg "Waiting to Heketi service to become ready"
       echo_do curl --retry-connrefused --retry 10 --retry-delay 5 127.0.0.1:8080/hello
       # Heketi ready
-      msg "Creating Gluster Topology file /etc/heketi/topology-olcne.json"
+      msg "Creating Gluster Topology file /etc/heketi/topology-ocne.json"
       # https://github.com/heketi/heketi/blob/master/docs/admin/topology.md
-      jq -R '{clusters:[{nodes:(./","|map({node:{hostnames:{manage:[.],storage:[.]},zone:1},devices:[{name:"/dev/sdb",destroydata:false}]}))}]}' <<< "${WORKERS}" > /vagrant/topology-olcne.json
-      echo_do sudo cp /vagrant/topology-olcne.json /etc/heketi/topology-olcne.json
-      echo_do sudo chown heketi: /etc/heketi/topology-olcne.json
+      jq -R '{clusters:[{nodes:(./","|map({node:{hostnames:{manage:[.],storage:[.]},zone:1},devices:[{name:"/dev/sdb",destroydata:false}]}))}]}' <<< "${WORKERS}" > /vagrant/topology-ocne.json
+      echo_do sudo cp /vagrant/topology-ocne.json /etc/heketi/topology-ocne.json
+      echo_do sudo chown heketi: /etc/heketi/topology-ocne.json
       msg "Loading Gluster Cluster Topology with Heketi"
       # export HEKETI_CLI_USER=admin; export HEKTI_CLI_KEY=secret
-      echo_do heketi-cli --user=admin --secret=secret topology load --json=/etc/heketi/topology-olcne.json
-      echo_do rm -f /vagrant/topology-olcne.json
+      echo_do heketi-cli --user=admin --secret=secret topology load --json=/etc/heketi/topology-ocne.json
+      echo_do rm -f /vagrant/topology-ocne.json
     fi
   fi
   
@@ -437,36 +437,35 @@ passwordless_ssh() {
   # Generate common key
   if [[ ! -f /vagrant/id_rsa ]]; then
     msg "Generating shared SSH keypair in PEM format"
-    echo_do ssh-keygen -m PEM -t rsa -f /vagrant/id_rsa -q -N "''" -C "'vagrant@olcne'"
+    echo_do ssh-keygen -m PEM -t rsa -f /vagrant/id_rsa -q -N "''" -C "'vagrant@ocne'"
   fi
   # Generate known_hosts
   if [[ ! -f /vagrant/known_hosts ]]; then
     msg "Generating shared SSH Known Hosts file"
-    echo_do touch /vagrant/known_hosts
+    echo_do cp /dev/null /vagrant/known_hosts
   fi  
-  # Install private key
-  echo_do cp /vagrant/id_rsa ~/.ssh
-  echo_do cp /vagrant/id_rsa.pub ~/.ssh
+  # Install private key & set permissions
+  echo_do "[ -d ~/.ssh ] || ( mkdir ~/.ssh && chmod 0700 ~/.ssh )"
+  echo_do "[ -f ~/.ssh/id_rsa ] || ( cp /vagrant/id_rsa ~/.ssh && chmod 0600 ~/.ssh/id_rsa )"
   # Authorise passwordless ssh
-  echo_do "cat /vagrant/id_rsa.pub >> ~/.ssh/authorized_keys"
-  # Set permissions
-  echo_do chmod 0700 ~/.ssh
-  echo_do chmod 0600 ~/.ssh/authorized_keys ~/.ssh/id_rsa
-  echo_do chmod 0644 ~/.ssh/authorized_keys ~/.ssh/id_rsa.pub
+  echo_do "[ -f ~/.ssh/id_rsa.pub ] || ( cp /vagrant/id_rsa.pub ~/.ssh && echo_do chmod 0644 ~/.ssh/id_rsa.pub && cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys )"
   # SSH Host Keys. Should really use ssh-keyscan -t ecdsa,ed25519
-  echo_do eval 'echo "`hostname -s`,`hostname -f`,`hostname -I|sed "s/ $//;s/ /,/g"` `cat /etc/ssh/ssh_host_ed25519_key.pub`" >> /vagrant/known_hosts'  
+  echo_do eval 'echo "`hostname -s`,`hostname -f`,`hostname -I|sed "s/ $//;s/ /,/g"` `cat /etc/ssh/ssh_host_ed25519_key.pub`" >> /vagrant/known_hosts'
   # Last node removes the key
   if [[ ${OPERATOR} == 1 ]]; then
-    msg "Removing the shared SSH keypair"
-    echo_do rm /vagrant/id_rsa /vagrant/id_rsa.pub
-
-    msg "Copying SSH Host Keys"
-    echo_do sudo cp /vagrant/known_hosts /etc/ssh/ssh_known_hosts
-    for node in ${MASTERS//,/ } ${WORKERS//,/ }; do
+    if [[ -f /vagrant/id_rsa && -f /vagrant/id_rsa.pub ]]; then
+      msg "Removing the shared SSH keypair"
+      echo_do rm /vagrant/id_rsa /vagrant/id_rsa.pub
+    fi
+    if [[ -f /vagrant/known_hosts ]]; then
+      msg "Copying SSH Host Keys to allow StrictHostKeyChecking"
+      echo_do "[ -f /etc/ssh/ssh_known_hosts ] || sudo cp /vagrant/known_hosts /etc/ssh/ssh_known_hosts"
+      for node in ${MASTERS//,/ } ${WORKERS//,/ }; do
 	echo_do ssh "${node}" "sudo cp /vagrant/known_hosts /etc/ssh/ssh_known_hosts"
-    done
-    msg "Removing the shared SSH Known Hosts file"
-    echo_do rm /vagrant/known_hosts
+      done
+      msg "Removing the shared SSH Known Hosts file"
+      echo_do rm /vagrant/known_hosts
+    fi
   fi
 }
 
@@ -504,7 +503,7 @@ certificates() {
 }
 
 #######################################
-# Bootstrap OLCNE
+# Bootstrap OCNE
 # Globals:
 #   CERT_DIR MASTERS WORKERS
 # Arguments:
@@ -512,10 +511,10 @@ certificates() {
 # Returns:
 #   None
 #######################################
-bootstrap_olcne() {
+bootstrap_ocne() {
   local node
 
-  msg "Bootstrap the Oracle Linux Cloud Native Environment Platform Agent on all nodes"
+  msg "Bootstrap the Oracle Cloud Native Environment Platform Agent on all nodes"
   echo_do sudo /etc/olcne/bootstrap-olcne.sh \
     --secret-manager-type file \
     --olcne-node-cert-path ${CERT_DIR}/production/node.cert \
@@ -537,8 +536,8 @@ bootstrap_olcne() {
 # Deploy Kubernetes cluster
 # Globals:
 #   CERT_DIR MASTERS MULTI_MASTER
-#   OLCNE_CLUSTER_NAME OLCNE_ENV_NAME
-#   REGISTRY_OLCNE NGINX_IMAGE
+#   OCNE_CLUSTER_NAME OCNE_ENV_NAME
+#   REGISTRY_OCNE NGINX_IMAGE
 # Arguments:
 #   None
 # Returns:
@@ -549,25 +548,25 @@ deploy_kubernetes() {
   master_nodes="${MASTERS//,/:8090,}:8090"
   worker_nodes="${WORKERS//,/:8090,}:8090"
 
-  msg "Create the Oracle Linux Cloud Native Environment: ${OLCNE_ENV_NAME}"
+  msg "Create the Oracle Cloud Native Environment: ${OCNE_ENV_NAME}"
   echo_do olcnectl environment create \
       --api-server 127.0.0.1:8091 \
-      --environment-name "${OLCNE_ENV_NAME}" \
+      --environment-name "${OCNE_ENV_NAME}" \
       --secret-manager-type file \
       --olcne-node-cert-path ${CERT_DIR}/production/node.cert \
       --olcne-ca-path ${CERT_DIR}/production/ca.cert \
       --olcne-node-key-path ${CERT_DIR}/production/node.key \
       --update-config
 
-  msg "Create the Kubernetes module for ${OLCNE_ENV_NAME} "
+  msg "Create the Kubernetes module for ${OCNE_ENV_NAME} "
   if [[ ${MULTI_MASTER} == 0 ]]; then
     # Single master
     echo_do olcnectl module create \
-      --environment-name "${OLCNE_ENV_NAME}" \
+      --environment-name "${OCNE_ENV_NAME}" \
       --selinux enforcing \
-      --module kubernetes --name "${OLCNE_CLUSTER_NAME}" \
-      --container-registry "${REGISTRY_OLCNE}" \
-      --nginx-image "${REGISTRY_OLCNE}/${NGINX_IMAGE}" \
+      --module kubernetes --name "${OCNE_CLUSTER_NAME}" \
+      --container-registry "${REGISTRY_OCNE}" \
+      --nginx-image "${REGISTRY_OCNE}/${NGINX_IMAGE}" \
       --pod-network-iface eth1 \
       --master-nodes "${master_nodes}" \
       --worker-nodes "${worker_nodes}" \
@@ -577,11 +576,11 @@ deploy_kubernetes() {
   else
     # HA Multi-master
     echo_do olcnectl module create \
-      --environment-name "${OLCNE_ENV_NAME}" \
+      --environment-name "${OCNE_ENV_NAME}" \
       --selinux enforcing \
-      --module kubernetes --name "${OLCNE_CLUSTER_NAME}" \
-      --container-registry "${REGISTRY_OLCNE}" \
-      --nginx-image "${REGISTRY_OLCNE}/${NGINX_IMAGE}" \
+      --module kubernetes --name "${OCNE_CLUSTER_NAME}" \
+      --container-registry "${REGISTRY_OCNE}" \
+      --nginx-image "${REGISTRY_OCNE}/${NGINX_IMAGE}" \
       --pod-network-iface eth1 \
       --virtual-ip "${SUBNET}.99" \
       --master-nodes "${master_nodes}" \
@@ -593,23 +592,23 @@ deploy_kubernetes() {
 
   msg "Validate all required prerequisites are met for the Kubernetes module"
   echo_do olcnectl module validate \
-    --environment-name "${OLCNE_ENV_NAME}" \
-    --name "${OLCNE_CLUSTER_NAME}"
+    --environment-name "${OCNE_ENV_NAME}" \
+    --name "${OCNE_CLUSTER_NAME}"
 
-  msg "Deploy the Kubernetes module into ${OLCNE_ENV_NAME} (Be patient!)"
+  msg "Deploy the Kubernetes module into ${OCNE_ENV_NAME} (Be patient!)"
   echo_do olcnectl module install \
-    --environment-name "${OLCNE_ENV_NAME}" \
-    --name "${OLCNE_CLUSTER_NAME}"
+    --environment-name "${OCNE_ENV_NAME}" \
+    --name "${OCNE_CLUSTER_NAME}"
 }
 
 #######################################
 # Deploy additional modules
 # Globals:
-#   OLCNE_CLUSTER_NAME OLCNE_ENV_NAME
+#   OCNE_CLUSTER_NAME OCNE_ENV_NAME
 #   DEPLOY_HELM HELM_MODULE_NAME
 #   DEPLOY_ISTIO ISTIO_MODULE_NAME
 #   DEPLOY_GLUSTER GLUSTER_MODULE_NAME
-#   REGISTRY_OLCNE
+#   REGISTRY_OCNE
 # Arguments:
 #   None
 # Returns:
@@ -626,21 +625,21 @@ deploy_modules() {
     # Create the Helm module
     msg "Creating the Helm module: ${HELM_MODULE_NAME}"
     echo_do olcnectl module create \
-      --environment-name "${OLCNE_ENV_NAME}" \
+      --environment-name "${OCNE_ENV_NAME}" \
       --module helm \
       --name "${HELM_MODULE_NAME}" \
-      --helm-kubernetes-module "${OLCNE_CLUSTER_NAME}"
+      --helm-kubernetes-module "${OCNE_CLUSTER_NAME}"
 
     # Validate the Helm module
     msg "Validating the Helm module: ${HELM_MODULE_NAME}"
     echo_do olcnectl module validate \
-      --environment-name "${OLCNE_ENV_NAME}" \
+      --environment-name "${OCNE_ENV_NAME}" \
       --name "${HELM_MODULE_NAME}"
 
     # Deploy the Helm module
-    msg "Deploying the Helm module: ${HELM_MODULE_NAME} into ${OLCNE_CLUSTER_NAME}"
+    msg "Deploying the Helm module: ${HELM_MODULE_NAME} into ${OCNE_CLUSTER_NAME}"
     echo_do olcnectl module install \
-      --environment-name "${OLCNE_ENV_NAME}" \
+      --environment-name "${OCNE_ENV_NAME}" \
       --name "${HELM_MODULE_NAME}"
   fi
 
@@ -650,23 +649,23 @@ deploy_modules() {
     # Create the Istio module
     msg "Creating the Istio module: ${ISTIO_MODULE_NAME}"
     echo_do olcnectl module create \
-      --environment-name "${OLCNE_ENV_NAME}" \
+      --environment-name "${OCNE_ENV_NAME}" \
       --module istio \
       --name "${ISTIO_MODULE_NAME}" \
-      --istio-container-registry "${REGISTRY_OLCNE}" \
+      --istio-container-registry "${REGISTRY_OCNE}" \
       --istio-helm-module "${HELM_MODULE_NAME}"
 
 
     # Validate the Istio module
     msg "Validating the Istio module: ${ISTIO_MODULE_NAME}"
     echo_do olcnectl module validate \
-      --environment-name "${OLCNE_ENV_NAME}" \
+      --environment-name "${OCNE_ENV_NAME}" \
       --name "${ISTIO_MODULE_NAME}"
 
     # Deploy the Istio module
-    msg "Deploying the Istio module: ${ISTIO_MODULE_NAME} into ${OLCNE_CLUSTER_NAME}"
+    msg "Deploying the Istio module: ${ISTIO_MODULE_NAME} into ${OCNE_CLUSTER_NAME}"
     echo_do olcnectl module install \
-      --environment-name "${OLCNE_ENV_NAME}" \
+      --environment-name "${OCNE_ENV_NAME}" \
       --name "${ISTIO_MODULE_NAME}"
   fi
 
@@ -682,7 +681,7 @@ deploy_modules() {
       HEKETI_CLI_SERVER="http://${SUBNET}.100:8080"
     fi
     echo_do olcnectl module create \
-      --environment-name "${OLCNE_ENV_NAME}" \
+      --environment-name "${OCNE_ENV_NAME}" \
       --module gluster \
       --name "${GLUSTER_MODULE_NAME}" \
       --gluster-helm-module "${HELM_MODULE_NAME}" \
@@ -691,13 +690,13 @@ deploy_modules() {
     # Validate the Gluster module
     msg "Validating the Gluster module: ${Gluster_MODULE_NAME}"
     echo_do olcnectl module validate \
-      --environment-name "${OLCNE_ENV_NAME}" \
+      --environment-name "${OCNE_ENV_NAME}" \
       --name "${GLUSTER_MODULE_NAME}"
 
     # Deploy the Gluster module
-    msg "Deploying the Gluster module: ${GLUSTER_MODULE_NAME} into ${OLCNE_CLUSTER_NAME}"
+    msg "Deploying the Gluster module: ${GLUSTER_MODULE_NAME} into ${OCNE_CLUSTER_NAME}"
     echo_do olcnectl module install \
-      --environment-name "${OLCNE_ENV_NAME}" \
+      --environment-name "${OCNE_ENV_NAME}" \
       --name "${GLUSTER_MODULE_NAME}"
   fi
 
@@ -846,7 +845,7 @@ fixups() {
 ready() {
   local node
 
-  msg "Your Oracle Linux Cloud Native Environment is operational."
+  msg "Your Oracle Cloud Native Environment is operational."
   node=${MASTERS//,*/}
   ssh vagrant@"${node}" kubectl get nodes
 }
@@ -865,7 +864,7 @@ main () {
   # All nodes are up, orchestrate installation
   if [[ ${OPERATOR} == 1 ]]; then
     certificates
-    bootstrap_olcne
+    bootstrap_ocne
     deploy_kubernetes
     deploy_modules
     fixups


### PR DESCRIPTION
Signed-off-by: Hussam Qasem <hqasem@tyeb.com>

Renames references from "Oracle Linux Cloud Native Environment" to "Oracle Cloud Native Environment".

This commit causes the following environment variables to be ignored:
* `OLCNE_DEV` now `OCNE_DEV`
* `REGISTRY_OLCNE` now `REGISTRY_OCNE`
* `OLCNE_ENV_NAME` now `OCNE_ENV_NAME`
* `OLCNE_CLUSTER_NAME` now `OCNE_CLUSTER_NAME`