### PR TITLE
Add OracleLinux/9 project

### DIFF
--- a/ContainerTools/README.md
+++ b/ContainerTools/README.md
@@ -4,9 +4,10 @@ A Vagrantfile that installs and configures the Container Tools module on Oracle 
 This module provides the tools to use container runtimes. That is: mainly Podman, but also Buildah, Skopeo...
 
 __Note:__ This Vagrant project is deprecated. However, the same functionality is
-available as an extension to the OracleLinux/8 project. For more information,
-see the [Container Tools](../OracleLinux/8/README.md#container-tools) section of
-the OracleLinux/8 [README.md](../OracleLinux/8/README.md) file.
+available as an extension to the OracleLinux/8 and OracleLinux/9 projects. For
+more information, see the Container Tools section of the Oracle Linux/8
+[README.md](../OracleLinux/8/README.md#container-tools) file or the Oracle
+Linux/9 [README.md](../OracleLinux/9/README.md#container-tools) file.
 
 ## Prerequisites
 1. Install [Oracle VM VirtualBox](https://www.virtualbox.org/wiki/Downloads)

--- a/OracleLinux/9/.env
+++ b/OracleLinux/9/.env
@@ -1,0 +1,18 @@
+# Oracle Linux 9 configuration file
+#
+# Requires vagrant-env plugin
+#
+# This file will be overwritten on updates, it is recommended to make changes
+# in .env.local
+
+# Extensions
+# To enable extensions, uncomment one or more EXTEND/EXPOSE definition:
+
+# The podman, buildah, and skopeo Container tools
+# EXTEND=$EXTEND,container-tools
+
+# Example for 'my-extension' using port 80
+# Run script 'scripts.local/my-extension.sh':
+# EXTEND=$EXTEND,my-extension
+# Expose guest port 80 to host port 8080:
+# EXPOSE=$EXPOSE,8080:80

--- a/OracleLinux/9/.gitattributes
+++ b/OracleLinux/9/.gitattributes
@@ -1,0 +1,1 @@
+*.sh	text eol=lf

--- a/OracleLinux/9/.gitignore
+++ b/OracleLinux/9/.gitignore
@@ -1,0 +1,3 @@
+.env.local
+scripts.local
+*.swp

--- a/OracleLinux/9/README.md
+++ b/OracleLinux/9/README.md
@@ -74,7 +74,7 @@ Set in your environment:
 EXTEND=container-tools
 ```
 
-Within the guest, run **podman** commands, for example `podman run -it oraclelinux:7-slim` to run an Oracle Linux 7 container, or `podman run -ti oraclelinux:8-slim` to run an Oracle Linux 8 container
+Within the guest, run **podman** commands, for example `podman run -it oraclelinux:8-slim` to run an Oracle Linux 8 container, or `podman run -ti oraclelinux:9-slim` to run an Oracle Linux 9 container
 
 ## Other info
 

--- a/OracleLinux/9/README.md
+++ b/OracleLinux/9/README.md
@@ -1,0 +1,82 @@
+# ol9-vagrant
+
+A Vagrant project to automatically build an Oracle Linux 9 virtual machine using either VirtualBox or libvirtd with optional extras including a container runtime.
+
+## Prerequisites
+
+Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM
+
+## Getting started
+
+1. Clone this repository `git clone https://github.com/oracle/vagrant-projects`
+1. Change into the `vagrant-projects/OracleLinux/9` directory
+1. Run `vagrant status` to check Vagrantfile status and possible plugin(s) required
+1. Run `vagrant up`
+   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection!
+   1. The Vagrant file allows for customization.
+1. SSH into the VM either by using `vagrant ssh`
+   If required, by Vagrantfile you can also setup ssh port forwarding.
+1. You can shut down the VM via the usual `vagrant halt` and the start it up again via `vagrant up`.
+
+## Optional plugins
+
+When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+
+- [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
+variables from .env files;
+- [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
+proxies in the guest VMs if you need to access the Internet through proxy. See
+plugin documentation for the configuration.
+- [vagrant-reload](https://github.com/aidanns/vagrant-reload): reload the VM
+during provisioning to activate the latest kernel.
+
+To install Vagrant plugins run:
+
+```shell
+vagrant plugin install <name>...
+```
+
+## Extending the project
+
+This project can easily be extended by running additional scripts during provisioning and optionally expose guest ports on the host.
+
+Environment variables are used to pass the parameters to the Vagrantfile:
+
+- `EXTEND`: comma separated list of extensions.
+   For each specified extension a script named `<extension>.sh` is automatically run during provisioning.
+   Scripts must be located in the `scripts` or `scripts.local` directory.
+- `EXPOSE`: comma separated list of ports to expose in the format: `<host port>:<guest port>`
+
+Example: to extend the project with the `container-tools` extension:
+
+- On a Linux or macOS host:
+   `EXTEND=container-tools vagrant up`
+- On a Windows host:
+   `set EXTEND=container-tools && vagrant up`
+
+Alternatively, if the `vagrant-env` plugin is installed, variables can be defined in the `.env` or `.env.local` files.
+
+Additionally, you can pass parameters to extensions using environment variables having a name starting with the extension name in uppercase followed by an underscore. E.g., for a Linux host:
+
+```shell
+EXTEND=my-extension MY_EXTENSION_PARAM=1234 vagrant up
+```
+
+## Sample extension
+
+### Container Tools
+
+Installs the **podman**, **buildah**, and **skopeo** [Container Tools](https://docs.oracle.com/en/operating-systems/oracle-linux/9/relnotes9.0/ol9.0-NewFeaturesandChanges.html#ol-features-containers).
+
+Set in your environment:
+
+```shell
+EXTEND=container-tools
+```
+
+Within the guest, run **podman** commands, for example `podman run -it oraclelinux:7-slim` to run an Oracle Linux 7 container, or `podman run -ti oraclelinux:8-slim` to run an Oracle Linux 8 container
+
+## Other info
+
+- If you need to, you can connect to the machine via `vagrant ssh`.
+- The directory in which the `Vagrantfile` is located is automatically mounted into the guest at `/vagrant` as a shared folder.

--- a/OracleLinux/9/Vagrantfile
+++ b/OracleLinux/9/Vagrantfile
@@ -1,0 +1,151 @@
+#
+# LICENSE UPL 1.0
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+#
+# Since: January, 2020
+# Author: gerald.venzl@oracle.com
+# Description: Creates an Oracle Linux virtual machine.
+# Optional plugins:
+#     vagrant-env (use .env files for configuration)
+#     vagrant-proxyconf (if you don't have direct access to the Internet)
+#         see https://github.com/tmatilai/vagrant-proxyconf for configuration
+#     vagrant-reload (allow VM reload during provisioning)
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+# NOTE:
+# If you use the VirtualBox provider, and modify this Vagrantfile to add one or
+# more network interfaces, you must specify the virtio nic type, or provisioning
+# will fail. For example:
+#   config.vm.network "private_network", ip: "192.168.50.4", nic_type: "virtio"
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+# Box metadata location and box name
+BOX_URL = "https://oracle.github.io/vagrant-projects/boxes"
+BOX_NAME = "oraclelinux/9"
+
+# define hostname
+NAME = "ol9-vagrant"
+
+# UI object for printing information
+ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = BOX_NAME
+  config.vm.box_url = "#{BOX_URL}/#{BOX_NAME}.json"
+  config.vm.define NAME
+
+  if Vagrant.has_plugin?("vagrant-env")
+    ui.info "Loading environment from .env files"
+    config.env.load(".env.local", ".env")
+  end
+
+  # change memory size
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+    v.name = NAME
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = 2048
+  end
+
+  # add proxy configuration from host env - optional
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+    ui.info "Getting Proxy Configuration from Host..."
+    has_proxy = false
+    ["http_proxy", "HTTP_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTP proxy: " + proxy
+        config.proxy.http = proxy
+        has_proxy = true
+        break
+      end
+    end
+
+    ["https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTPS proxy: " + proxy
+        config.proxy.https = proxy
+        has_proxy = true
+        break
+      end
+    end
+
+    if has_proxy
+      # Only consider no_proxy if we have proxies defined.
+      no_proxy = ""
+      ["no_proxy", "NO_PROXY"].each do |proxy_var|
+        if ENV[proxy_var]
+          no_proxy = ENV[proxy_var]
+          ui.info "No proxy: " + no_proxy
+          no_proxy += ","
+          break
+        end
+      end
+      config.proxy.no_proxy = no_proxy + "localhost,.vagrant.vm"
+    end
+  else
+    ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if ENV[proxy_var]
+        ui.warn 'To enable proxies in your VM, install the vagrant-proxyconf plugin'
+        break
+      end
+    end
+  end
+
+  # VM hostname
+  config.vm.hostname = NAME
+
+  # Oracle port forwarding
+  # config.vm.network "forwarded_port", guest: 22, host: 2220
+
+  # Provision everything on the first run
+  config.vm.provision "shell", path: "scripts/install.sh"
+  if Vagrant.has_plugin?("vagrant-reload")
+    config.vm.provision "shell", inline: "echo 'Reloading your VM to activate the latest kernel'"
+    config.vm.provision :reload
+  else
+    config.vm.provision "shell", inline: "echo 'You need to reload your VM to activate the latest kernel'"
+  end
+
+  # Extend provisioning
+  if ENV['EXTEND']
+    ENV['EXTEND'].sub(/^[ ,]+/,'').split(/[ ,]+/).each do |extension|
+      found = false
+      ["scripts", "scripts.local"].each do |script_dir|
+        script = "#{script_dir}/#{extension}.sh"
+        if File.file?(script)
+          ui.info "Extension #{extension} using #{script} enabled"
+          found = true
+          config.vm.provision "shell", inline: "echo 'Running provisioner for extension #{extension}'"
+          config.vm.provision "shell",
+            path: script,
+            env: ENV.select { |key, value| key.to_s.match(/^#{extension.upcase.gsub('-','_')}_/) }
+          break
+        end
+      end
+      unless found
+        ui.error "Extension #{extension} does not exist -- ignored"
+      end
+    end
+  end
+
+  # Expose ports to the host
+  if ENV['EXPOSE']
+    ENV['EXPOSE'].sub(/^[ ,]+/,'').split(/[ ,]+/).each do |expose|
+      host_port, guest_port = expose.split(':')
+      ui.info "Guest port #{guest_port} exposed to port #{host_port} on host"
+      config.vm.network "forwarded_port", guest: guest_port, host: host_port
+    end
+  end
+
+  config.vm.provision "shell", inline: "echo 'INSTALLER: Installation complete, Oracle Linux 9 ready to use!'"
+
+end

--- a/OracleLinux/9/Vagrantfile
+++ b/OracleLinux/9/Vagrantfile
@@ -1,10 +1,8 @@
 #
-# LICENSE UPL 1.0
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
-#
-# Since: January, 2020
-# Author: gerald.venzl@oracle.com
 # Description: Creates an Oracle Linux virtual machine.
 # Optional plugins:
 #     vagrant-env (use .env files for configuration)

--- a/OracleLinux/9/scripts/container-tools.sh
+++ b/OracleLinux/9/scripts/container-tools.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Provisioning script for the Container Tools module
+#
+# Copyright (c) 2020 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# Description: Installs the podman, buildah and skopeo Container Tools
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+echo 'Installing Container Tools meta-package'
+
+dnf -y install container-tools
+
+echo 'Container Tools are ready to use'
+echo 'To get started, on your host, run:'
+echo '  vagrant ssh'
+echo
+echo 'Then, within the guest (for example):'
+echo '  podman run -it --rm oraclelinux:9-slim'
+echo

--- a/OracleLinux/9/scripts/container-tools.sh
+++ b/OracleLinux/9/scripts/container-tools.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# Provisioning script for the Container Tools module
+# Provisioning script for the Container Tools meta-package
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2022 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl.
 #

--- a/OracleLinux/9/scripts/install.sh
+++ b/OracleLinux/9/scripts/install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# LICENSE UPL 1.0
+#
+# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
+#
+# Since: January, 2018
+# Author: gerald.venzl@oracle.com
+# Description: Updates Oracle Linux to the latest version
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+echo 'INSTALLER: Started up'
+
+# get up to date
+dnf upgrade -y
+
+echo 'INSTALLER: System updated'
+
+# fix locale warning
+echo LANG=en_US.utf-8 >> /etc/environment
+echo LC_ALL=en_US.utf-8 >> /etc/environment
+
+echo 'INSTALLER: Locale set'

--- a/OracleLinux/9/scripts/install.sh
+++ b/OracleLinux/9/scripts/install.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 #
-# LICENSE UPL 1.0
+# Copyright (c) 2022 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
-#
-# Since: January, 2018
-# Author: gerald.venzl@oracle.com
 # Description: Updates Oracle Linux to the latest version
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.


### PR DESCRIPTION
Adds an OracleLinux/9 project, based on the OracleLinux/8 project.

Changes from the OracleLinux/8 project:

- Updated the Oracle Linux version number wherever needed
- Added a comment to the `Vagrantfile` to note that the virtio nic type must be specified if adding network interfaces when using the VirtualBox provider
- Updated the `container-tools.sh` extension script to install the container-tools meta-package, rather than the container-tools module, since the module doesn't seem to be available yet

Also updated the `README.md` file for the ContainerTools project to state that the Container Tools functionality is available as an extension to both the OracleLinux/8 and OracleLinux/9 projects.

Closes #451.

I'm happy to make any changes that you'd like.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>