### PR TITLE
feat(ocne): Upgrade to OL8 UEKR7

### DIFF
--- a/OCNE/.env
+++ b/OCNE/.env
@@ -15,8 +15,8 @@
 # SUBNET=192.168.99
 
 # Set vCPU count and memory for the VMs:
-#   +  2 vCPU/1770MB memory minimum for Master node(s)
-#   +  1 vCPU/648MB memory minimum for Worker node(s)
+#   +  2 vCPU/1770MB absloute memory minimum for Master node(s)
+#   +  1 vCPU/700MB absloute memory minimum for Worker node(s)
 #   +  3GB memory minimum required for Istio module on Worker nodes
 # OPERATOR_CPUS=1
 # OPERATOR_MEMORY=1024

--- a/OCNE/README.md
+++ b/OCNE/README.md
@@ -16,7 +16,7 @@ Environment Platform Agent installed and configured to communicate with the
 Platform API Server on the operator node.
 
 The installation includes the Kubernetes module for Oracle Cloud
-Native Environment which deploys Kubernetes 1.22.8 configured to use
+Native Environment which deploys Kubernetes [1.24.8](https://docs.oracle.com/en/operating-systems/olcne/1.5/relnotes/components.html#d672e108) configured to use
 the CRI-O runtime interface. Two runtime engines are installed, runc and
 Kata Containers.
 
@@ -66,8 +66,8 @@ To obtain token from any Master node, you may run: `kubectl -n kubernetes-dashbo
 The VMs communicate via a private network:
 
 - Controller node IP: 192.168.99.100 (if `STANDALONE_OPERATOR=true`)
-- Master node _i_: 192.168.99.(100_+i_) / master*_i_*.vagrant.vm
-- Worker node _i_: 192.168.99.(110_+i_) / worker*_i_*.vagrant.vm
+- Master node _i_: 192.168.99.(100+i) / master_i_.vagrant.vm
+- Worker node _i_: 192.168.99.(110+i) / worker_i_.vagrant.vm
 - Master Virtual IP: 192.168.99.99 (if `MULTI_MASTER=true`)
 - LoadBalancer IPs: 192.168.99.240 - 192.168.99.250 (if `DEPLOY_METALLB=true`)
 

--- a/OCNE/Vagrantfile
+++ b/OCNE/Vagrantfile
@@ -1,7 +1,7 @@
 #
 # Vagrantfile for Oracle Cloud Native Environment
 #
-# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2019-2022 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl.
 #

--- a/OCNE/scripts/provision.sh
+++ b/OCNE/scripts/provision.sh
@@ -2,7 +2,7 @@
 #
 # Provision Oracle Cloud Native Environment nodes
 #
-# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2019-2022 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl.
 #
@@ -255,7 +255,7 @@ setup_repos() {
 
   # Add OCNE release package
   echo_do sudo dnf install -y oracle-olcne-release-el8
-  echo_do sudo dnf config-manager --enable ol8_olcne15 ol8_baseos_latest ol8_appstream ol8_addons ol8_UEKR6
+  echo_do sudo dnf config-manager --enable ol8_olcne15 ol8_baseos_latest ol8_appstream ol8_addons ol8_kvm_appstream ol8_UEKR7
   echo_do sudo dnf config-manager --disable ol8_olcne12 ol8_olcne13 ol8_olcne14
 
   # Optional extra repo
@@ -331,9 +331,11 @@ install_packages() {
     echo_do sudo dnf install -y olcnectl"${OCNE_VERSION}" olcne-api-server"${OCNE_VERSION}" olcne-utils"${OCNE_VERSION}"
     echo_do sudo systemctl enable olcne-api-server.service
     echo_do sudo firewall-cmd --add-port=8091/tcp --permanent
-    echo_do sudo firewall-cmd --add-masquerade --permanent
+    #echo_do sudo firewall-cmd --add-masquerade --permanent
   fi
   if [[ ${MASTER} == 1 || ${WORKER} == 1 ]]; then
+    msg "Installing the OpenSSL toolkit"
+    echo_do sudo dnf install -y openssl
     msg "Installing the Oracle Cloud Native Environment Platform Agent"
     echo_do sudo dnf install -y olcne-agent"${OCNE_VERSION}" olcne-utils"${OCNE_VERSION}"
     echo_do sudo systemctl enable olcne-agent.service
@@ -347,7 +349,7 @@ install_packages() {
 	Environment=\"NO_PROXY=${NO_PROXY}\"
 	EOF"
     fi
-    echo_do sudo firewall-cmd --add-masquerade --permanent
+    #echo_do sudo firewall-cmd --add-masquerade --permanent
     echo_do sudo firewall-cmd --zone=trusted --add-interface=cni0 --permanent
     echo_do sudo firewall-cmd --add-port=8090/tcp --permanent
     echo_do sudo firewall-cmd --add-port=10250/tcp --permanent
@@ -372,7 +374,7 @@ install_packages() {
   fi
 
   if [[ ${DEPLOY_METALLB} == 1 ]]; then
-    if [[ ${WORKER} == 1 ]]; then
+    if [[ ${MASTER} == 1 || ${WORKER} == 1 ]]; then
       echo_do sudo firewall-cmd --add-port=7946/tcp --permanent
       echo_do sudo firewall-cmd --add-port=7946/udp --permanent
     fi
@@ -393,7 +395,7 @@ install_packages() {
       echo_do eval "cat /etc/ssl/glusterfs.pem >> /vagrant/glusterfs.ca"
       echo_do sudo touch /var/lib/glusterd/secure-access
       echo_do sudo systemctl enable --now glusterd.service
-      echo_do sudo firewall-cmd --permanent --add-service=glusterfs
+      echo_do sudo firewall-cmd --add-service=glusterfs --permanent
     fi
 
     if [[ ${OPERATOR} == 1 ]]; then
@@ -791,6 +793,16 @@ fixups() {
       echo 'command -v istioctl >/dev/null 2>&1 && source <(istioctl completion bash)' >> ~/.bashrc; \
       \""
   done
+
+  # Fix: /usr/libexec/crio/conmon doesn't exist
+  #      conmon in @ol8_x86_64_appstream overrides @ol8_x86_64_olcne15
+  msg "Change conmon from /usr/libexec/crio/conmon to /usr/bin/conmon in /etc/crio/crio.conf"
+  for node in ${MASTERS//,/ } ${WORKERS//,/ }; do
+    echo_do ssh "${node}" "\"\
+      sudo sed 's|/usr/libexec/crio/conmon|/usr/bin/conmon|' -i /etc/crio/crio.conf \
+      && sudo systemctl restart crio.service \
+    \""
+  done  
 
   msg "Starting kubectl proxy service on master nodes"
   for node in ${MASTERS//,/ }; do


### PR DESCRIPTION
#461 
- Upgrade to OL8 [UEKR7](https://docs.oracle.com/en/operating-systems/olcne/1.5/relnotes/new.html#ocne-157)
- Change `Virtualbox` `nic_type` to `virtio` drivers.
- Install `openssl` toolkit package.
- Change `conmon` from `/usr/libexec/crio/conmon` to `/usr/bin/conmon` in `/etc/crio/crio.conf` - as `conmon` in `@ol8_x86_64_appstream` now overrides `@ol8_x86_64_olcne15`
- Remove `firewall-cmd --add-masquerade` from provisioning script issue #460 .

Signed-off-by: Hussam Qasem <hqasem@tyeb.com>