### PR TITLE
feat(ocne): Upgrade to OL8 UEKR7

### DIFF
--- a/OCNE/.env
+++ b/OCNE/.env
@@ -15,8 +15,8 @@
 # SUBNET=192.168.99
 
 # Set vCPU count and memory for the VMs:
-#   +  2 vCPU/1770MB memory minimum for Master node(s)
-#   +  1 vCPU/648MB memory minimum for Worker node(s)
+#   +  2 vCPU/1770MB absloute memory minimum for Master node(s)
+#   +  1 vCPU/700MB absloute memory minimum for Worker node(s)
 #   +  3GB memory minimum required for Istio module on Worker nodes
 # OPERATOR_CPUS=1
 # OPERATOR_MEMORY=1024

--- a/OCNE/README.md
+++ b/OCNE/README.md
@@ -16,7 +16,7 @@ Environment Platform Agent installed and configured to communicate with the
 Platform API Server on the operator node.
 
 The installation includes the Kubernetes module for Oracle Cloud
-Native Environment which deploys Kubernetes 1.22.8 configured to use
+Native Environment which deploys Kubernetes [1.24.8](https://docs.oracle.com/en/operating-systems/olcne/1.5/relnotes/components.html#d672e108) configured to use
 the CRI-O runtime interface. Two runtime engines are installed, runc and
 Kata Containers.
 
@@ -66,8 +66,8 @@ To obtain token from any Master node, you may run: `kubectl -n kubernetes-dashbo
 The VMs communicate via a private network:
 
 - Controller node IP: 192.168.99.100 (if `STANDALONE_OPERATOR=true`)
-- Master node _i_: 192.168.99.(100_+i_) / master*_i_*.vagrant.vm
-- Worker node _i_: 192.168.99.(110_+i_) / worker*_i_*.vagrant.vm
+- Master node _i_: 192.168.99.(100+ _i_ ) / master *_i_* .vagrant.vm
+- Worker node _i_: 192.168.99.(110+ _i_ ) / worker *_i_* .vagrant.vm
 - Master Virtual IP: 192.168.99.99 (if `MULTI_MASTER=true`)
 - LoadBalancer IPs: 192.168.99.240 - 192.168.99.250 (if `DEPLOY_METALLB=true`)
 

--- a/OCNE/Vagrantfile
+++ b/OCNE/Vagrantfile
@@ -1,7 +1,7 @@
 #
 # Vagrantfile for Oracle Cloud Native Environment
 #
-# Copyright (c) 2019, 2021 Oracle and/or its affiliates.
+# Copyright (c) 2019, 2022 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl.
 #
@@ -247,7 +247,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ip = 110 + i
       ip_addr = "#{SUBNET}.#{ip}"
       workers += "#{ip_addr},"
-      worker.vm.network :private_network, ip: ip_addr
+      worker.vm.network :private_network, nic_type: "virtio", ip: ip_addr
       if Vagrant.has_plugin?("vagrant-hosts")
         worker.vm.provision :hosts, :sync_hosts => true, :add_localhost_hostnames => false
       end
@@ -281,7 +281,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ip = 100 + i
       ip_addr = "#{SUBNET}.#{ip}"
       masters += "#{ip_addr},"
-      master.vm.network :private_network, ip: ip_addr
+      master.vm.network :private_network, nic_type: "virtio", ip: ip_addr
       if Vagrant.has_plugin?("vagrant-hosts")
         master.vm.provision :hosts, :sync_hosts => true, :add_localhost_hostnames => false
       end
@@ -316,7 +316,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if STANDALONE_OPERATOR
     config.vm.define "operator" do |operator|
       operator.vm.hostname = "operator.vagrant.vm"
-      operator.vm.network :private_network, ip: "#{SUBNET}.100"
+      operator.vm.network :private_network, nic_type: "virtio", ip: "#{SUBNET}.100"
       if Vagrant.has_plugin?("vagrant-hosts")
         operator.vm.provision :hosts, :sync_hosts => true, :add_localhost_hostnames => false
       end

--- a/OCNE/scripts/provision.sh
+++ b/OCNE/scripts/provision.sh
@@ -326,16 +326,22 @@ requirements() {
 #######################################
 install_packages() {
 
+  ### `nft_masq` is not part of kernel-uek-core since OL8U7. To enable masquerading, we must install kernel-uek-modules
+  ### https://docs.oracle.com/en/operating-systems/uek/7/relnotes7.0/uek7.0-NewFeaturesandChanges.html
+  msg "Installing kernel-uek-modules"
+  echo_do sudo dnf install -y kernel-uek-modules-$(uname -r)
+  msg "Installing the OpenSSL toolkit"
+  echo_do sudo dnf install -y openssl
+  ###
+    
   if [[ ${OPERATOR} == 1 ]]; then
     msg "Installing the Oracle Cloud Native Environment Platform API Server and Platform CLI tool to the operator node."
     echo_do sudo dnf install -y olcnectl"${OCNE_VERSION}" olcne-api-server"${OCNE_VERSION}" olcne-utils"${OCNE_VERSION}"
     echo_do sudo systemctl enable olcne-api-server.service
     echo_do sudo firewall-cmd --add-port=8091/tcp --permanent
-    #echo_do sudo firewall-cmd --add-masquerade --permanent
+    echo_do sudo firewall-cmd --add-masquerade --permanent
   fi
   if [[ ${MASTER} == 1 || ${WORKER} == 1 ]]; then
-    msg "Installing the OpenSSL toolkit"
-    echo_do sudo dnf install -y openssl
     msg "Installing the Oracle Cloud Native Environment Platform Agent"
     echo_do sudo dnf install -y olcne-agent"${OCNE_VERSION}" olcne-utils"${OCNE_VERSION}"
     echo_do sudo systemctl enable olcne-agent.service
@@ -349,7 +355,7 @@ install_packages() {
 	Environment=\"NO_PROXY=${NO_PROXY}\"
 	EOF"
     fi
-    #echo_do sudo firewall-cmd --add-masquerade --permanent
+    echo_do sudo firewall-cmd --add-masquerade --permanent
     echo_do sudo firewall-cmd --zone=trusted --add-interface=cni0 --permanent
     echo_do sudo firewall-cmd --add-port=8090/tcp --permanent
     echo_do sudo firewall-cmd --add-port=10250/tcp --permanent


### PR DESCRIPTION
Ref: issue #461
- Upgrade to OL8 [UEKR7](https://docs.oracle.com/en/operating-systems/olcne/1.5/relnotes/new.html#ocne-157)
- Change `Vagrantfile` `Virtualbox` `nic_type` to `virtio` drivers.
- Install `openssl` toolkit package.
- Change `conmon` from `/usr/libexec/crio/conmon` to `/usr/bin/conmon` in `/etc/crio/crio.conf` - as `conmon` in `@ol8_x86_64_appstream` now overrides `@ol8_x86_64_olcne15`
- Remove `firewall-cmd --add-masquerade` from provisioning script issue #460 .

Signed-off-by: Hussam Qasem <hqasem@tyeb.com>