### PR TITLE
build(metadata): ⬆ new OL8U7 release for vagrant-virtualbox

### DIFF
--- a/boxes/oraclelinux/8-btrfs.json
+++ b/boxes/oraclelinux/8-btrfs.json
@@ -4,6 +4,21 @@
   "name": "oraclelinux/8-btrfs",
   "versions": [
     {
+      "version": "8.7.412",
+      "status": "active",
+      "release_date": "19-Dec-2022",
+      "description_html": "<ul>\n<li>Releasing 8.7.412</li>\n</ul>\n",
+      "description_markdown": "* Releasing 8.7.412",
+      "providers": [{
+        "name": "virtualbox",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol8/OL8U7_x86_64-vagrant-btrfs-virtualbox-b412.box",
+        "checksum": "36d26b7dbb6d0b69f165085767b38bf87d75e34535653a3d538d35ee6b7d6f3d",
+        "checksum_type": "sha256",
+        "size": 666235864,
+        "kernel": "5.15.0-5.76.5.1.el8uek.x86_64"
+      }]
+    },
+    {
       "version": "8.7.406",
       "status": "active",
       "release_date": "08-Dec-2022",

--- a/boxes/oraclelinux/8.json
+++ b/boxes/oraclelinux/8.json
@@ -4,6 +4,21 @@
   "name": "oraclelinux/8",
   "versions": [
     {
+      "version": "8.7.411",
+      "status": "active",
+      "release_date": "19-Dec-2022",
+      "description_html": "<ul>\n<li>Releasing 8.7.411</li>\n</ul>\n",
+      "description_markdown": "* Releasing 8.7.411",
+      "providers": [{
+        "name": "virtualbox",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol8/OL8U7_x86_64-vagrant-virtualbox-b411.box",
+        "checksum": "d69ad6882ff0777d4e6a638a5acef1e5f81c7566719b7da662ef67f27c4b9de5",
+        "checksum_type": "sha256",
+        "size": 728631026,
+        "kernel": "5.15.0-5.76.5.1.el8uek.x86_64"
+      }]
+    },
+    {
       "version": "8.7.405",
       "status": "active",
       "release_date": "08-Dec-2022",


### PR DESCRIPTION
Ready to be merged -- boxes are published on the public yum:

```
$ ~/src/olitt/olit-release-checks.sh  --version ol8 --cloud vagrant --provider virtualbox check-public
Running olit-release-checks.sh:
  Clouds   : vagrant
  Providers: virtualbox
  Versions : ol8

Fetching latest versions
Checking uploads against https://yum.oracle.com/
OL8U7_x86_64-vagrant-btrfs-virtualbox-b412.box: OK -- Content-Length: 666235864
OL8U7_x86_64-vagrant-virtualbox-b411.box: OK -- Content-Length: 728631026
```

and match metadata in this PR:

```
~/src/olitt/olit-release-checks.sh  --version ol8 --cloud vagrant --provider virtualbox check-meta
Running olit-release-checks.sh:
  Clouds   : vagrant
  Providers: virtualbox
  Versions : ol8

Fetching latest versions
Checking Vagrant metadata
/boxes/oraclelinux/ol8/OL8U7_x86_64-vagrant-virtualbox-b411.box: OK
/boxes/oraclelinux/ol8/OL8U7_x86_64-vagrant-btrfs-virtualbox-b412.box: OK
```

--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>