### PR TITLE
UEKR7 Fixes (take 2)

### DIFF
--- a/Ocr-Yum-Mirror/Vagrantfile
+++ b/Ocr-Yum-Mirror/Vagrantfile
@@ -46,18 +46,20 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # change memory size
   config.vm.provider "virtualbox" do |v|
-    v.memory = 2048
+    v.memory = 1024
     v.name = NAME
-  # add second disk device
+    # add second disk device
     file_to_disk = File.realpath( "." ).to_s + "/disk.vdi"
 
-    if ARGV[0] == "up" && ! File.exist?(file_to_disk)
-       v.customize [
-            'createhd',
-            '--filename', file_to_disk,
-            '--format', 'VDI',
-            '--size', 50 * 1024 # 50 GB
-            ]
+    if ARGV[0] == "up"
+       if ! File.exist?(file_to_disk)
+         v.customize [
+              'createhd',
+              '--filename', file_to_disk,
+              '--format', 'VDI',
+              '--size', 50 * 1024 # 50 GB
+              ]
+       end
        v.customize [
             'storageattach', :id,
             '--storagectl', 'SATA Controller', # The name may vary
@@ -126,8 +128,19 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "shell", path: "scripts/ocr-mirror.sh", privileged: false
 
   # Share Yum mirror and OCNE mirror access
-  config.vm.provision "shell", inline: "echo 'INSTALLER: Oracle Linux Yum Mirror is available at http://<host-machine>:8080/yum/'", privileged: false
-  config.vm.provision "shell", inline: "echo 'INSTALLER: Oracle Container Registry Mirror is available at https://<host-machine>:5000/olcne/'", privileged: false
-  config.vm.provision "shell", inline: "echo 'INSTALLER: Installation complete, Oracle Linux 8 ready to use!'", privileged: false
+  config.vm.post_up_message = <<-MSG
+    Installation complete, Oracle Linux 8 mirror ready to use!
+    
+    -----------------------------------------------------------
+    Local Ocr-Yum-Mirror, accessible via:
+      127.0.0.1 (localhost); or
+      10.0.2.2 (inside VirtualBox VMs)
+    
+    URLs:
+     - OracleLinux8 Yum Repo    - http://localhost:8080/yum/
+     - OCNE 1.6 Docker Registry - https://localhost:5000/olcne/
+    
+    -----------------------------------------------------------
+  MSG
 
 end

--- a/Ocr-Yum-Mirror/scripts/install.sh
+++ b/Ocr-Yum-Mirror/scripts/install.sh
@@ -31,9 +31,11 @@ EOF
 echo 'INSTALLER: Locale set'
 
 echo 'INSTALLER: Creating persistent virtual-disk /dev/sdb1'
-# persistent disk
-printf "o\nn\np\n1\n\n\nw\n" |sudo fdisk /dev/sdb
-sudo mkfs.xfs /dev/sdb1
+# persistent disk. check if xfs fs already exists
+if ! sudo blkid /dev/sdb1 | grep -q "TYPE=\"xfs\""; then
+    printf "o\nn\np\n1\n\n\nw\n" |sudo fdisk /dev/sdb
+    sudo mkfs.xfs /dev/sdb1
+fi
 sudo mkdir -p /var/yum
 sudo mount /dev/sdb1 /var/yum
 sudo chown vagrant: /var/yum

--- a/Ocr-Yum-Mirror/scripts/ocr-mirror.sh
+++ b/Ocr-Yum-Mirror/scripts/ocr-mirror.sh
@@ -49,11 +49,11 @@ podman run -d -p 5000:5000 --name ocr-yum-mirror --restart=always \
 
 # add sync script for OCR mirror
 cat <<EOF | tee /home/vagrant/sync-ocr.sh
-/usr/bin/registry-image-helper.sh --to ocr-yum-mirror:5000/olcne $*
+/usr/bin/registry-image-helper.sh --to ocr-yum-mirror:5000/olcne --version 1.25.7
 EOF
 chmod 700 /home/vagrant/sync-ocr.sh
 
 # collect OCNE container images
-/home/vagrant/sync-ocr.sh --version 1.25.7
+/home/vagrant/sync-ocr.sh
 
 echo 'OCR MIRROR SETUP: Completed'


### PR DESCRIPTION
OCNE 1.6:
* Install `kernel-uek-modules` as required by `nft_masq` for UEKR7 (fix Calico).
* Replace depracted `--<module>-helm-module` option with `--<module>-kubernetes-module` for OCNE 1.6

Ocr-Yum-Mirror:
* Re-mount `disk.vdi` if it exists, and don't initialize if xfs filesystem already exists.