### PR TITLE
build(metadata): :arrow_up: OL8U9 and OL9U2 release

### DIFF
--- a/boxes/oraclelinux/8-btrfs.json
+++ b/boxes/oraclelinux/8-btrfs.json
@@ -4,6 +4,36 @@
   "name": "oraclelinux/8-btrfs",
   "versions": [
     {
+      "version": "8.8.486",
+      "status": "active",
+      "release_date": "24-May-2023",
+      "description_html": "<ul>\n<li>Releasing 8.8.486</li>\n</ul>\n",
+      "description_markdown": "* Releasing 8.8.486",
+      "providers": [{
+        "name": "virtualbox",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol8/OL8U8_x86_64-vagrant-btrfs-virtualbox-b486.box",
+        "checksum": "de5db72043f62f366249ff2ff144b4b4f6b87edc4bdbdc000a20671ccfa6610a",
+        "checksum_type": "sha256",
+        "size": 663825976,
+        "kernel": "5.15.0-101.103.2.1.el8uek.x86_64"
+      }]
+    },
+    {
+      "version": "8.8.488",
+      "status": "active",
+      "release_date": "24-May-2023",
+      "description_html": "<ul>\n<li>Releasing 8.8.488</li>\n</ul>\n",
+      "description_markdown": "* Releasing 8.8.488",
+      "providers": [{
+        "name": "libvirt",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol8/OL8U8_x86_64-vagrant-btrfs-libvirt-b488.box",
+        "checksum": "a20a1e876e82521b0ee13019f186084afd91ca8cb317cd6ab451430194a45a8d",
+        "checksum_type": "sha256",
+        "size": 412946175,
+        "kernel": "5.15.0-101.103.2.1.el8uek.x86_64"
+      }]
+    },
+    {
       "version": "8.7.412",
       "status": "active",
       "release_date": "19-Dec-2022",

--- a/boxes/oraclelinux/8.json
+++ b/boxes/oraclelinux/8.json
@@ -4,6 +4,37 @@
   "name": "oraclelinux/8",
   "versions": [
     {
+      "version": "8.8.485",
+      "status": "active",
+      "release_date": "24-May-2023",
+      "description_html": "<ul>\n<li>Releasing 8.8.485</li>\n</ul>\n",
+      "description_markdown": "* Releasing 8.8.485",
+      "providers": [{
+        "name": "virtualbox",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol8/OL8U8_x86_64-vagrant-virtualbox-b485.box",
+        "checksum": "d2b6265e2a68cf41d08d1e1924320a4c60eb134c4b6e85dfc46650d521d2f59a",
+        "checksum_type": "sha256",
+        "size": 732557761,
+        "kernel": "5.15.0-101.103.2.1.el8uek.x86_64"
+      }]
+    },
+
+    {
+      "version": "8.8.487",
+      "status": "active",
+      "release_date": "24-May-2023",
+      "description_html": "<ul>\n<li>Releasing 8.8.487</li>\n</ul>\n",
+      "description_markdown": "* Releasing 8.8.487",
+      "providers": [{
+        "name": "libvirt",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol8/OL8U8_x86_64-vagrant-libvirt-b487.box",
+        "checksum": "efd470a6c0a1b657e7687036d690bb43368ab582a08c43c79a8742e9e757a27d",
+        "checksum_type": "sha256",
+        "size": 503618680,
+        "kernel": "5.15.0-101.103.2.1.el8uek.x86_64"
+      }]
+    },
+    {
       "version": "8.7.411",
       "status": "active",
       "release_date": "19-Dec-2022",

--- a/boxes/oraclelinux/9-btrfs.json
+++ b/boxes/oraclelinux/9-btrfs.json
@@ -4,6 +4,36 @@
   "name": "oraclelinux/9-btrfs",
   "versions": [
     {
+      "version": "9.2.482",
+      "status": "active",
+      "release_date": "22-May-2023",
+      "description_html": "<ul>\n<li>Releasing 9.2.482</li>\n</ul>\n",
+      "description_markdown": "* Releasing 9.2.482",
+      "providers": [{
+        "name": "virtualbox",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol9/OL9U2_x86_64-vagrant-btrfs-virtualbox-b482.box",
+        "checksum": "3cc745808c4ab881f455330fb42061383f43ed900108a30ebec56d2979253ca0",
+        "checksum_type": "sha256",
+        "size": 533312583,
+        "kernel": "5.15.0-101.103.2.1.el9uek.x86_64"
+      }]
+    },
+    {
+      "version": "9.2.484",
+      "status": "active",
+      "release_date": "22-May-2023",
+      "description_html": "<ul>\n<li>Releasing 9.2.484</li>\n</ul>\n",
+      "description_markdown": "* Releasing 9.2.484",
+      "providers": [{
+        "name": "libvirt",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol9/OL9U2_x86_64-vagrant-btrfs-libvirt-b484.box",
+        "checksum": "df6132509691c47e9e9bb69c20c5908a83d0db2bcb1c5d829adf83d88c2c28f1",
+        "checksum_type": "sha256",
+        "size": 454717858,
+        "kernel": "5.15.0-101.103.2.1.el9uek.x86_64"
+      }]
+    },
+    {
       "version": "9.1.408",
       "status": "active",
       "release_date": "08-Dec-2022",

--- a/boxes/oraclelinux/9.json
+++ b/boxes/oraclelinux/9.json
@@ -4,6 +4,36 @@
   "name": "oraclelinux/9",
   "versions": [
     {
+      "version": "9.2.481",
+      "status": "active",
+      "release_date": "22-May-2023",
+      "description_html": "<ul>\n<li>Releasing 9.2.481</li>\n</ul>\n",
+      "description_markdown": "* Releasing 9.2.481",
+      "providers": [{
+        "name": "virtualbox",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol9/OL9U2_x86_64-vagrant-virtualbox-b481.box",
+        "checksum": "099d5a182a356d255beb1baea27ab645587cd8e8b576688e43673ff03787c200",
+        "checksum_type": "sha256",
+        "size": 572465521,
+        "kernel": "5.15.0-101.103.2.1.el9uek.x86_64"
+      }]
+    },
+    {
+      "version": "9.2.483",
+      "status": "active",
+      "release_date": "22-May-2023",
+      "description_html": "<ul>\n<li>Releasing 9.2.483</li>\n</ul>\n",
+      "description_markdown": "* Releasing 9.2.483",
+      "providers": [{
+        "name": "libvirt",
+        "url": "https://yum.oracle.com/boxes/oraclelinux/ol9/OL9U2_x86_64-vagrant-libvirt-b483.box",
+        "checksum": "bb1cffd40a907cc552ec07939fcc9fadd29440d8ad4fa58721c1ef424937c08f",
+        "checksum_type": "sha256",
+        "size": 519447257,
+        "kernel": "5.15.0-101.103.2.1.el9uek.x86_64"
+      }]
+    },
+    {
       "version": "9.1.407",
       "status": "active",
       "release_date": "08-Dec-2022",


### PR DESCRIPTION
Metadata for the OL8U9 and OL9U2 boxes.

Verified against source metadata:

```text
Running olit-release-checks.sh:
  Clouds   : vagrant
  Providers: virtualbox libvirt
  Versions : ol8 ol9

Fetching latest versions
Checking Vagrant metadata
/boxes/oraclelinux/ol9/OL9U2_x86_64-vagrant-virtualbox-b481.box: OK
/boxes/oraclelinux/ol8/OL8U8_x86_64-vagrant-btrfs-libvirt-b488.box: OK
/boxes/oraclelinux/ol9/OL9U2_x86_64-vagrant-btrfs-virtualbox-b482.box: OK
/boxes/oraclelinux/ol9/OL9U2_x86_64-vagrant-libvirt-b483.box: OK
/boxes/oraclelinux/ol8/OL8U8_x86_64-vagrant-btrfs-virtualbox-b486.box: OK
/boxes/oraclelinux/ol8/OL8U8_x86_64-vagrant-virtualbox-b485.box: OK
/boxes/oraclelinux/ol9/OL9U2_x86_64-vagrant-btrfs-libvirt-b484.box: OK
/boxes/oraclelinux/ol8/OL8U8_x86_64-vagrant-libvirt-b487.box: OK
```
--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>

(Draft until boxes are available on yum.oracle.com)