### PR TITLE
Add OracleDatabase/23.4.0-Free project

### DIFF
--- a/OracleDatabase/23.4.0-Free/.env
+++ b/OracleDatabase/23.4.0-Free/.env
@@ -1,0 +1,35 @@
+# Oracle Database 23.4.0 Free configuration file
+#
+# Requires vagrant-env plugin
+#
+# This file will be overwritten on updates, so it is recommended to make
+# a copy of this file called .env.local, then make changes in .env.local.
+#
+# To change a parameter, uncomment it and set it to the desired value.
+# All commented parameters will retain their default values.
+
+# VM name
+# VM_NAME='oracle23ai-free-vagrant'
+
+# Memory for the VM (in MB, 2300 MB is ~2.25 GB)
+# VM_MEMORY=2300
+
+# VM time zone
+# If not specified, will be set to match host time zone (if possible)
+# Can use time zone name (e.g., 'America/Los_Angeles')
+# or an offset from GMT (e.g., 'Etc/GMT-2')
+# VM_SYSTEM_TIMEZONE=
+
+# Save database installer RPM file for reuse when VM is rebuilt
+# VM_KEEP_DB_INSTALLER=false
+
+# Database character set
+# VM_ORACLE_CHARACTERSET='AL32UTF8'
+
+# Listener port
+# VM_LISTENER_PORT=1521
+
+# Oracle Database password for SYS, SYSTEM and PDBADMIN accounts
+# If left blank, the password will be generated automatically
+# Database creation will fail if the password contains spaces or special characters
+# VM_ORACLE_PWD=

--- a/OracleDatabase/23.4.0-Free/.gitattributes
+++ b/OracleDatabase/23.4.0-Free/.gitattributes
@@ -1,0 +1,2 @@
+*.sh	text eol=lf
+*.tmpl	text eol=lf

--- a/OracleDatabase/23.4.0-Free/.gitignore
+++ b/OracleDatabase/23.4.0-Free/.gitignore
@@ -1,0 +1,2 @@
+*.rpm
+.env.local*

--- a/OracleDatabase/23.4.0-Free/README.md
+++ b/OracleDatabase/23.4.0-Free/README.md
@@ -1,0 +1,102 @@
+# oracle23ai-free-vagrant
+
+This Vagrant project provisions Oracle Database automatically, using Vagrant, an Oracle Linux 9 box and a shell script.
+
+## Prerequisites
+
+1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
+2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
+makes configuration much easier
+
+## Getting started
+
+1. Clone this repository `git clone https://github.com/oracle/vagrant-projects`
+2. Change into the `vagrant-projects/OracleDatabase/23.4.0-Free` directory
+3. Run `vagrant up`
+   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the VM to the latest via `dnf`.
+   2. The installation can be customized, if desired (see [Configuration](#configuration)).
+4. Connect to the database (see [Connecting to Oracle](#connecting-to-oracle))
+5. You can shut down the VM via the usual `vagrant halt` and then start it up again via `vagrant up`
+
+## Connecting to Oracle
+
+The default database connection parameters are:
+
+* Hostname: `localhost`
+* Port: `1521`
+* SID: `FREE`
+* PDB: `FREEPDB1`
+* Database passwords are auto-generated and printed on install
+
+These parameters can be customized, if desired (see [Configuration](#configuration)).
+
+## Resetting password
+
+You can reset the password of the Oracle database accounts (SYS, SYSTEM and PDBADMIN only) by switching to the oracle user (`sudo su - oracle`), then executing `/home/oracle/setPassword.sh <Your new password>`.
+
+## Running scripts after setup
+
+You can have the installer run scripts after setup by putting them in the `userscripts` directory below the directory where you have this file checked out. Any shell (`.sh`) or SQL (`.sql`) scripts you put in the `userscripts` directory will be executed by the installer after the database is set up and started. Only shell and SQL scripts will be executed; all other files will be ignored. These scripts are completely optional.
+
+Shell scripts will be executed as root. SQL scripts will be executed as SYS. SQL scripts will run against the CDB, not the PDB, unless you include an `ALTER SESSION SET CONTAINER = FREEPDB1` statement in the script.
+
+To run scripts in a specific order, prefix the file names with a number, e.g., `01_shellscript.sh`, `02_tablespaces.sql`, `03_shellscript2.sh`, etc.
+
+## Configuration
+
+The `Vagrantfile` can be used _as-is_, without any additional configuration. However, there are several parameters you can set to tailor the installation to your needs.
+
+### How to configure
+
+There are three ways to set parameters:
+
+1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
+2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
+3. Use the `.env`/`.env.local` files (requires
+[vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
+
+Parameters are considered in the following order (first one wins):
+
+1. Environment variables
+2. `.env.local` (if it exists and the  [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
+3. `.env` (if the [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
+4. `Vagrantfile` definitions
+
+### VM parameters
+
+* `VM_NAME` (default: `oracle23ai-free-vagrant`): VM name.
+* `VM_MEMORY` (default: `2300`): memory for the VM (in MB, 2300 MB is ~2.25 GB).
+* `VM_SYSTEM_TIMEZONE` (default: host time zone (if possible)): VM time zone.
+  * The system time zone is used by the database for SYSDATE/SYSTIMESTAMP.
+  * The guest time zone will be set to the host time zone when the host time zone is a full hour offset from GMT.
+  * When the host time zone isn't a full hour offset from GMT (e.g., in India and parts of Australia), the guest time zone will be set to UTC.
+  * You can specify a different time zone using a time zone name (e.g., "America/Los_Angeles") or an offset from GMT (e.g., "Etc/GMT-2"). For more information on specifying time zones, see [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
+### Oracle Database parameters
+
+* `VM_KEEP_DB_INSTALLER` (default: `false`): save database installer RPM file for reuse when VM is rebuilt.
+* `VM_ORACLE_CHARACTERSET` (default: `AL32UTF8`): database character set.
+* `VM_LISTENER_PORT` (default: `1521`): Listener port.
+* `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS, SYSTEM and PDBADMIN accounts. **Important: Database creation will fail if the password contains spaces or special characters.**
+
+## Optional plugins
+
+When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+
+* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
+variables from .env files;
+* [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
+proxies in the guest VM if you need to access the Internet through a proxy. See
+the plugin documentation for configuration.
+
+To install Vagrant plugins run:
+
+```shell
+vagrant plugin install <name>...
+```
+
+## Other info
+
+* If you need to, you can connect to the virtual machine via `vagrant ssh`.
+* You can `sudo su - oracle` to switch to the oracle user.
+* On the guest OS, the directory `/vagrant` is a shared folder and maps to wherever you have this file checked out.

--- a/OracleDatabase/23.4.0-Free/Vagrantfile
+++ b/OracleDatabase/23.4.0-Free/Vagrantfile
@@ -1,0 +1,163 @@
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# Since: July, 2018
+# Author: gerald.venzl@oracle.com
+# Description: Creates an Oracle database Vagrant virtual machine.
+# Optional plugins:
+#     vagrant-env (use .env files for configuration)
+#     vagrant-proxyconf (if you don't have direct access to the Internet)
+#         see https://github.com/tmatilai/vagrant-proxyconf for configuration
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+# Box metadata location and box name
+BOX_URL = "https://oracle.github.io/vagrant-projects/boxes"
+BOX_NAME = "oraclelinux/9"
+
+# UI object for printing information
+ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
+
+# Define constants
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Use vagrant-env plugin if available
+  if Vagrant.has_plugin?("vagrant-env")
+    config.env.load(".env.local", ".env") # enable the plugin
+  end
+
+  # VM name
+  VM_NAME = default_s('VM_NAME', 'oracle23ai-free-vagrant')
+
+  # Memory for the VM (in MB, 2300 MB is ~2.25 GB)
+  VM_MEMORY = default_i('VM_MEMORY', 2300)
+
+  # VM time zone
+  # If not specified, will be set to match host time zone (if possible)
+  VM_SYSTEM_TIMEZONE = default_s('VM_SYSTEM_TIMEZONE', host_tz)
+
+  # Save database installer RPM file for reuse when VM is rebuilt
+  VM_KEEP_DB_INSTALLER = default_b('VM_KEEP_DB_INSTALLER', false)
+
+  # Database character set
+  VM_ORACLE_CHARACTERSET = default_s('VM_ORACLE_CHARACTERSET', 'AL32UTF8')
+
+  # Listener port
+  VM_LISTENER_PORT = default_i('VM_LISTENER_PORT', 1521)
+
+  # Oracle Database password for SYS, SYSTEM and PDBADMIN accounts
+  # If left blank, the password will be generated automatically
+  # Database creation will fail if the password contains spaces or special characters
+  VM_ORACLE_PWD = default_s('VM_ORACLE_PWD', '')
+end
+
+# Convenience methods
+def default_s(key, default)
+  ENV[key] && ! ENV[key].empty? ? ENV[key] : default
+end
+
+def default_i(key, default)
+  default_s(key, default).to_i
+end
+
+def default_b(key, default)
+  default_s(key, default).to_s.downcase == "true"
+end
+
+def host_tz
+  # get host time zone for setting VM time zone
+  # if host time zone isn't an integer hour offset from GMT, fall back to UTC
+  offset_sec = Time.now.gmt_offset
+  if (offset_sec % (60 * 60)) == 0
+    offset_hr = ((offset_sec / 60) / 60)
+    timezone_suffix = offset_hr >= 0 ? "-#{offset_hr.to_s}" : "+#{(-offset_hr).to_s}"
+    'Etc/GMT' + timezone_suffix
+  else
+    'UTC'
+  end
+end
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = BOX_NAME
+  config.vm.box_url = "#{BOX_URL}/#{BOX_NAME}.json"
+  config.vm.define VM_NAME
+
+  # Provider-specific configuration
+  config.vm.provider "virtualbox" do |v|
+    v.memory = VM_MEMORY
+    v.name = VM_NAME
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = VM_MEMORY
+  end
+
+  # add proxy configuration from host env - optional
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+    ui.info "Getting Proxy Configuration from Host..."
+    has_proxy = false
+    ["http_proxy", "HTTP_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTP proxy: " + proxy
+        config.proxy.http = proxy
+        has_proxy = true
+        break
+      end
+    end
+
+    ["https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if proxy = ENV[proxy_var]
+        ui.info "HTTPS proxy: " + proxy
+        config.proxy.https = proxy
+        has_proxy = true
+        break
+      end
+    end
+
+    if has_proxy
+      # Only consider no_proxy if we have proxies defined.
+      no_proxy = ""
+      ["no_proxy", "NO_PROXY"].each do |proxy_var|
+        if ENV[proxy_var]
+          no_proxy = ENV[proxy_var]
+          ui.info "No proxy: " + no_proxy
+          no_proxy += ","
+          break
+        end
+      end
+      config.proxy.no_proxy = no_proxy + "localhost,127.0.0.1"
+    end
+  else
+    ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"].each do |proxy_var|
+      if ENV[proxy_var]
+        ui.warn 'To enable proxies in your VM, install the vagrant-proxyconf plugin'
+        break
+      end
+    end
+  end
+
+  # VM hostname
+  # must be "localhost", or listener configuration will fail
+  config.vm.hostname = "localhost"
+
+  # Oracle port forwarding
+  config.vm.network "forwarded_port", guest: VM_LISTENER_PORT, host: VM_LISTENER_PORT
+
+  # Provision everything on the first run
+  config.vm.provision "shell", path: "scripts/install.sh", env:
+    {
+       "SYSTEM_TIMEZONE"     => VM_SYSTEM_TIMEZONE,
+       "KEEP_DB_INSTALLER"   => VM_KEEP_DB_INSTALLER,
+       "ORACLE_CHARACTERSET" => VM_ORACLE_CHARACTERSET,
+       "LISTENER_PORT"       => VM_LISTENER_PORT,
+       "ORACLE_PWD"          => VM_ORACLE_PWD
+    }
+
+end

--- a/OracleDatabase/23.4.0-Free/ora-response/oracle-free-23ai.conf.tmpl
+++ b/OracleDatabase/23.4.0-Free/ora-response/oracle-free-23ai.conf.tmpl
@@ -1,0 +1,25 @@
+#This is a configuration file to setup the Oracle Database. 
+#It is used when running '/etc/init.d/oracle-free-23ai configure'.
+
+# LISTENER PORT used Database listener, Leave empty for automatic port assignment
+LISTENER_PORT=###LISTENER_PORT###
+
+# Character set of the database
+CHARSET=###ORACLE_CHARACTERSET###
+
+# Database file directory
+# If not specified, database files are stored under Oracle base/oradata
+DBFILE_DEST=
+
+# DB Domain name
+DB_DOMAIN=
+
+# Configure TDE
+CONFIGURE_TDE=false
+
+# Encrypt Tablespaces list, Leave empty for user tablespace alone or provide ALL for encrypting all tablespaces
+# For specific tablespaces use SYSTEM:true,SYSAUX:false
+ENCRYPT_TABLESPACES=
+
+# SKIP Validations, memory, space
+SKIP_VALIDATIONS=false

--- a/OracleDatabase/23.4.0-Free/scripts/install.sh
+++ b/OracleDatabase/23.4.0-Free/scripts/install.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+#
+# Copyright (c) 2024 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# Since: July, 2018
+# Author: gerald.venzl@oracle.com
+# Description: Installs Oracle database software
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+# Abort on any error
+set -Eeuo pipefail
+
+echo 'INSTALLER: Started up'
+
+# get up to date
+dnf upgrade -y
+
+echo 'INSTALLER: System updated'
+
+# fix locale warning
+dnf reinstall -y glibc-common
+echo 'LANG=en_US.utf-8' >> /etc/environment
+echo 'LC_ALL=en_US.utf-8' >> /etc/environment
+
+echo 'INSTALLER: Locale set'
+
+# set system time zone
+timedatectl set-timezone "$SYSTEM_TIMEZONE"
+echo "INSTALLER: System time zone set to $SYSTEM_TIMEZONE"
+
+# Install Oracle Database preinstall and openssl packages
+dnf install -y oracle-database-preinstall-23ai openssl
+
+echo 'INSTALLER: Oracle preinstall and openssl complete'
+
+# set environment variables
+cat >> /home/oracle/.bashrc << EOF
+export ORACLE_BASE=/opt/oracle
+export ORACLE_HOME=/opt/oracle/product/23ai/dbhomeFree
+export ORACLE_SID=FREE
+export PATH=\$PATH:\$ORACLE_HOME/bin
+EOF
+
+echo 'INSTALLER: Environment variables set'
+
+# Install Oracle
+# if installer doesn't exist, download it
+db_installer='oracle-database-free-23ai-1.0-1.el9.x86_64.rpm'
+if [[ ! -f /vagrant/"${db_installer}" ]]; then
+  echo 'INSTALLER: Downloading Oracle Database software'
+  curl -Ls -o /vagrant/"${db_installer}" \
+       https://download.oracle.com/otn-pub/otn_software/db-free/"${db_installer}"
+fi
+
+dnf -y install /vagrant/"${db_installer}"
+
+if [[ "${KEEP_DB_INSTALLER,,}" == 'false' ]]; then
+  rm -f /vagrant/"${db_installer}"
+fi
+
+echo 'INSTALLER: Oracle software installed'
+
+# Auto generate ORACLE PWD if not passed in
+export ORACLE_PWD=${ORACLE_PWD:-"$(openssl rand -base64 9)1"}
+
+# Create database
+cfg_file='/etc/sysconfig/oracle-free-23ai.conf'
+mv "${cfg_file}" "${cfg_file}".original
+cp /vagrant/ora-response/oracle-free-23ai.conf.tmpl "${cfg_file}"
+chmod g+w "${cfg_file}"
+
+sed -i -e "s|###LISTENER_PORT###|$LISTENER_PORT|g" "${cfg_file}"
+sed -i -e "s|###ORACLE_CHARACTERSET###|$ORACLE_CHARACTERSET|g" "${cfg_file}"
+(echo "${ORACLE_PWD}"; echo "${ORACLE_PWD}") | /etc/init.d/oracle-free-23ai configure
+
+chmod o+r /opt/oracle/product/23ai/dbhomeFree/network/admin/tnsnames.ora
+
+# add tnsnames.ora entry for PDB
+cat >> /opt/oracle/product/23ai/dbhomeFree/network/admin/tnsnames.ora << EOF
+FREEPDB1 =
+  (DESCRIPTION =
+    (ADDRESS = (PROTOCOL = TCP)(HOST = localhost)(PORT = $LISTENER_PORT))
+    (CONNECT_DATA =
+      (SERVER = DEDICATED)
+      (SERVICE_NAME = FREEPDB1)
+    )
+  )
+EOF
+
+echo 'INSTALLER: Database created'
+
+# configure systemd to start Oracle instance on startup
+systemctl daemon-reload
+systemctl enable oracle-free-23ai
+systemctl start oracle-free-23ai
+echo 'INSTALLER: Created and enabled oracle-free-23ai systemd service'
+
+cp /vagrant/scripts/setPassword.sh /home/oracle/
+chown oracle:oinstall /home/oracle/setPassword.sh
+chmod u=rwx,go=r /home/oracle/setPassword.sh
+
+echo 'INSTALLER: setPassword.sh file set up'
+
+# run user-defined post-setup scripts
+echo 'INSTALLER: Running user-defined post-setup scripts'
+
+for f in /vagrant/userscripts/*
+  do
+    case "${f,,}" in
+      *.sh)
+        echo "INSTALLER: Running $f"
+        # shellcheck disable=SC1090
+        . "$f"
+        echo "INSTALLER: Done running $f"
+        ;;
+      *.sql)
+        echo "INSTALLER: Running $f"
+        su -l oracle -c "echo 'exit' | sqlplus -s / as sysdba @\"$f\""
+        echo "INSTALLER: Done running $f"
+        ;;
+      /vagrant/userscripts/put_custom_scripts_here.txt)
+        :
+        ;;
+      *)
+        echo "INSTALLER: Ignoring $f"
+        ;;
+    esac
+  done
+
+echo 'INSTALLER: Done running user-defined post-setup scripts'
+
+echo "ORACLE PASSWORD FOR SYS, SYSTEM AND PDBADMIN: $ORACLE_PWD"
+
+echo 'INSTALLER: Installation complete, database ready to use!'

--- a/OracleDatabase/23.4.0-Free/scripts/setPassword.sh
+++ b/OracleDatabase/23.4.0-Free/scripts/setPassword.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+# Since: November, 2016
+# Author: gerald.venzl@oracle.com
+# Description: Sets the password for sys, system and pdbadmin
+#
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+
+ORACLE_PWD=$1
+ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
+ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v pdbseed | awk '{print $9}' | cut -d/ -f6`"
+ORAENV_ASK=NO
+source oraenv
+
+sqlplus / as sysdba << EOF
+      ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
+      ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
+      ALTER SESSION SET CONTAINER=$ORACLE_PDB;
+      ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD";
+      exit;
+EOF
+

--- a/OracleDatabase/23.4.0-Free/userscripts/.gitignore
+++ b/OracleDatabase/23.4.0-Free/userscripts/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!put_custom_scripts_here.txt

--- a/OracleDatabase/23.4.0-Free/userscripts/put_custom_scripts_here.txt
+++ b/OracleDatabase/23.4.0-Free/userscripts/put_custom_scripts_here.txt
@@ -1,0 +1,14 @@
+Any shell (.sh) or SQL (.sql) scripts you put in this directory
+will be executed by the installer after the database is set up
+and started.  Only shell and SQL scripts will be executed; all
+other files will be ignored.  These scripts are completely
+optional.
+
+Shell scripts will be executed as root.  SQL scripts will be
+executed as SYS.  SQL scripts will run against the CDB, not the
+PDB, unless you include an ALTER SESSION SET CONTAINER = FREEPDB1
+statement in the script.
+
+To run scripts in a specific order, prefix the file names with a
+number, e.g., 01_shellscript.sh, 02_tablespaces.sql,
+03_shellscript2.sh, etc.


### PR DESCRIPTION
Adds an Oracle Database 23ai Free project, based on the OracleDatabase/23.3.0-Free project. Since the 23.3.0-Free rpm is still available for download, this is a new project, rather than an update to the 23.3.0-Free project.

Notable changes from the 23.3.0-Free project:

- Use Oracle Linux 9 instead of Oracle Linux 8
- Add notes to `.env`, `README.md` and `Vagrantfile` stating that database creation will fail if the password includes special characters
- Modify `install.sh` to prevent auto-generated passwords from containing equals signs

Tested with both VirtualBox and libvirt/KVM.

Closes #505.

I'm happy to make any changes that you'd like.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>