### PR TITLE
Oracle DB 23ai Free - Prevent special chars in generated passwords

### DIFF
--- a/OracleDatabase/23.4.0-Free/scripts/install.sh
+++ b/OracleDatabase/23.4.0-Free/scripts/install.sh
@@ -65,7 +65,7 @@ fi
 echo 'INSTALLER: Oracle software installed'
 
 # Auto generate ORACLE PWD if not passed in
-export ORACLE_PWD=${ORACLE_PWD:-"$(openssl rand -base64 9)1"}
+export ORACLE_PWD=${ORACLE_PWD:-"$(openssl rand -hex 8)1"}
 
 # Create database
 cfg_file='/etc/sysconfig/oracle-free-23ai.conf'


### PR DESCRIPTION
For the Oracle Database 23ai Free project, change the method used by `install.sh` to auto-generate passwords from `openssl rand -base64` to `openssl rand -hex`. This prevents including special characters in the generated password that would cause database creation to fail.

(Also, change the `openssl rand` "num" parameter from 9 to 8, to be consistent with the other single-instance database projects in this repository.)

I'm happy to make any changes that you'd like.

Fixes #515

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>