### PR TITLE
Modify setPassword.sh to work with multiple PDBs

### DIFF
--- a/OracleDatabase/12.1.0.2/scripts/setPassword.sh
+++ b/OracleDatabase/12.1.0.2/scripts/setPassword.sh
@@ -1,26 +1,54 @@
 #!/bin/bash
-# LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.
-# 
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
 # Since: November, 2016
 # Author: gerald.venzl@oracle.com
-# Description: Sets the password for sys, system and pdb_admin
+# Description: Sets the password for sys, system and pdbadmin
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-# 
+#
+
+# Abort on any error
+set -Eeuo pipefail
 
 ORACLE_PWD=$1
-ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
-ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v pdbseed | awk '{print $9}' | cut -d/ -f6`"
-ORAENV_ASK=NO
-source oraenv
 
 sqlplus / as sysdba << EOF
-      ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
-      ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
-      ALTER SESSION SET CONTAINER=$ORACLE_PDB;
-      ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD";
-      exit;
+  ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
+  ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
 EOF
 
+echo 'Setting PDBADMIN password in open PDBs'
+
+set_pdbadmin_pw=$(mktemp)
+trap 'rm -f "${set_pdbadmin_pw}"' EXIT
+
+sqlplus -s / as sysdba > "${set_pdbadmin_pw}" << EOF
+  SET HEADING OFF LINESIZE 120 PAGESIZE 0
+  SELECT   'ALTER SESSION SET CONTAINER = ' || name || ';' || CHR(10)
+        || 'SET SERVEROUTPUT ON' || CHR(10)
+        || 'BEGIN' || CHR(10)
+        || '  EXECUTE IMMEDIATE ''ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD"'';' || CHR(10)
+        || '  DBMS_OUTPUT.PUT_LINE (''Set PDBADMIN password in ' || name || ' PDB'');' || CHR(10)
+        || 'EXCEPTION' || CHR(10)
+        || '  WHEN OTHERS THEN' || CHR(10)
+        || '    IF SQLCODE = -1918 THEN' || CHR(10)
+        || '      DBMS_OUTPUT.PUT_LINE (''PDBADMIN user not found in ' || name || ' PDB'');' || CHR(10)
+        || '    ELSE' || CHR(10)
+        || '      RAISE;' || CHR(10)
+        || '    END IF;' || CHR(10)
+        || 'END;' || CHR(10)
+        || '/'
+  FROM     v\$pdbs
+  WHERE    open_mode = 'READ WRITE'
+  ORDER BY name;
+EOF
+
+sed -i -e 's|no rows selected|PROMPT No open PDBs found|' "${set_pdbadmin_pw}"
+
+echo 'EXIT' | sqlplus -s / as sysdba @"${set_pdbadmin_pw}"
+
+echo 'Done setting PDBADMIN password in open PDBs'

--- a/OracleDatabase/12.2.0.1/scripts/setPassword.sh
+++ b/OracleDatabase/12.2.0.1/scripts/setPassword.sh
@@ -1,26 +1,54 @@
 #!/bin/bash
-# LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2016 Oracle and/or its affiliates. All rights reserved.
-# 
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
 # Since: November, 2016
 # Author: gerald.venzl@oracle.com
-# Description: Sets the password for sys, system and pdb_admin
+# Description: Sets the password for sys, system and pdbadmin
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-# 
+#
+
+# Abort on any error
+set -Eeuo pipefail
 
 ORACLE_PWD=$1
-ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
-ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v pdbseed | awk '{print $9}' | cut -d/ -f6`"
-ORAENV_ASK=NO
-source oraenv
 
 sqlplus / as sysdba << EOF
-      ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
-      ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
-      ALTER SESSION SET CONTAINER=$ORACLE_PDB;
-      ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD";
-      exit;
+  ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
+  ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
 EOF
 
+echo 'Setting PDBADMIN password in open PDBs'
+
+set_pdbadmin_pw=$(mktemp)
+trap 'rm -f "${set_pdbadmin_pw}"' EXIT
+
+sqlplus -s / as sysdba > "${set_pdbadmin_pw}" << EOF
+  SET HEADING OFF LINESIZE 120 PAGESIZE 0
+  SELECT   'ALTER SESSION SET CONTAINER = ' || name || ';' || CHR(10)
+        || 'SET SERVEROUTPUT ON' || CHR(10)
+        || 'BEGIN' || CHR(10)
+        || '  EXECUTE IMMEDIATE ''ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD"'';' || CHR(10)
+        || '  DBMS_OUTPUT.PUT_LINE (''Set PDBADMIN password in ' || name || ' PDB'');' || CHR(10)
+        || 'EXCEPTION' || CHR(10)
+        || '  WHEN OTHERS THEN' || CHR(10)
+        || '    IF SQLCODE = -1918 THEN' || CHR(10)
+        || '      DBMS_OUTPUT.PUT_LINE (''PDBADMIN user not found in ' || name || ' PDB'');' || CHR(10)
+        || '    ELSE' || CHR(10)
+        || '      RAISE;' || CHR(10)
+        || '    END IF;' || CHR(10)
+        || 'END;' || CHR(10)
+        || '/'
+  FROM     v\$pdbs
+  WHERE    open_mode = 'READ WRITE'
+  ORDER BY name;
+EOF
+
+sed -i -e 's|no rows selected|PROMPT No open PDBs found|' "${set_pdbadmin_pw}"
+
+echo 'EXIT' | sqlplus -s / as sysdba @"${set_pdbadmin_pw}"
+
+echo 'Done setting PDBADMIN password in open PDBs'

--- a/OracleDatabase/18.3.0/scripts/setPassword.sh
+++ b/OracleDatabase/18.3.0/scripts/setPassword.sh
@@ -1,26 +1,54 @@
 #!/bin/bash
-# LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
-# 
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
 # Since: November, 2016
 # Author: gerald.venzl@oracle.com
-# Description: Sets the password for sys, system and pdb_admin
+# Description: Sets the password for sys, system and pdbadmin
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-# 
+#
+
+# Abort on any error
+set -Eeuo pipefail
 
 ORACLE_PWD=$1
-ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
-ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v pdbseed | awk '{print $9}' | cut -d/ -f6`"
-ORAENV_ASK=NO
-source oraenv
 
 sqlplus / as sysdba << EOF
-      ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
-      ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
-      ALTER SESSION SET CONTAINER=$ORACLE_PDB;
-      ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD";
-      exit;
+  ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
+  ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
 EOF
 
+echo 'Setting PDBADMIN password in open PDBs'
+
+set_pdbadmin_pw=$(mktemp)
+trap 'rm -f "${set_pdbadmin_pw}"' EXIT
+
+sqlplus -s / as sysdba > "${set_pdbadmin_pw}" << EOF
+  SET HEADING OFF LINESIZE 120 PAGESIZE 0
+  SELECT   'ALTER SESSION SET CONTAINER = ' || name || ';' || CHR(10)
+        || 'SET SERVEROUTPUT ON' || CHR(10)
+        || 'BEGIN' || CHR(10)
+        || '  EXECUTE IMMEDIATE ''ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD"'';' || CHR(10)
+        || '  DBMS_OUTPUT.PUT_LINE (''Set PDBADMIN password in ' || name || ' PDB'');' || CHR(10)
+        || 'EXCEPTION' || CHR(10)
+        || '  WHEN OTHERS THEN' || CHR(10)
+        || '    IF SQLCODE = -1918 THEN' || CHR(10)
+        || '      DBMS_OUTPUT.PUT_LINE (''PDBADMIN user not found in ' || name || ' PDB'');' || CHR(10)
+        || '    ELSE' || CHR(10)
+        || '      RAISE;' || CHR(10)
+        || '    END IF;' || CHR(10)
+        || 'END;' || CHR(10)
+        || '/'
+  FROM     v\$pdbs
+  WHERE    open_mode = 'READ WRITE'
+  ORDER BY name;
+EOF
+
+sed -i -e 's|no rows selected|PROMPT No open PDBs found|' "${set_pdbadmin_pw}"
+
+echo 'EXIT' | sqlplus -s / as sysdba @"${set_pdbadmin_pw}"
+
+echo 'Done setting PDBADMIN password in open PDBs'

--- a/OracleDatabase/18.4.0-XE/scripts/setPassword.sh
+++ b/OracleDatabase/18.4.0-XE/scripts/setPassword.sh
@@ -1,26 +1,54 @@
 #!/bin/bash
-# LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
-# 
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
 # Since: November, 2016
 # Author: gerald.venzl@oracle.com
-# Description: Sets the password for sys, system and pdb_admin
+# Description: Sets the password for sys, system and pdbadmin
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-# 
+#
+
+# Abort on any error
+set -Eeuo pipefail
 
 ORACLE_PWD=$1
-ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
-ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v pdbseed | awk '{print $9}' | cut -d/ -f6`"
-ORAENV_ASK=NO
-source oraenv
 
 sqlplus / as sysdba << EOF
-      ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
-      ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
-      ALTER SESSION SET CONTAINER=$ORACLE_PDB;
-      ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD";
-      exit;
+  ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
+  ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
 EOF
 
+echo 'Setting PDBADMIN password in open PDBs'
+
+set_pdbadmin_pw=$(mktemp)
+trap 'rm -f "${set_pdbadmin_pw}"' EXIT
+
+sqlplus -s / as sysdba > "${set_pdbadmin_pw}" << EOF
+  SET HEADING OFF LINESIZE 120 PAGESIZE 0
+  SELECT   'ALTER SESSION SET CONTAINER = ' || name || ';' || CHR(10)
+        || 'SET SERVEROUTPUT ON' || CHR(10)
+        || 'BEGIN' || CHR(10)
+        || '  EXECUTE IMMEDIATE ''ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD"'';' || CHR(10)
+        || '  DBMS_OUTPUT.PUT_LINE (''Set PDBADMIN password in ' || name || ' PDB'');' || CHR(10)
+        || 'EXCEPTION' || CHR(10)
+        || '  WHEN OTHERS THEN' || CHR(10)
+        || '    IF SQLCODE = -1918 THEN' || CHR(10)
+        || '      DBMS_OUTPUT.PUT_LINE (''PDBADMIN user not found in ' || name || ' PDB'');' || CHR(10)
+        || '    ELSE' || CHR(10)
+        || '      RAISE;' || CHR(10)
+        || '    END IF;' || CHR(10)
+        || 'END;' || CHR(10)
+        || '/'
+  FROM     v\$pdbs
+  WHERE    open_mode = 'READ WRITE'
+  ORDER BY name;
+EOF
+
+sed -i -e 's|no rows selected|PROMPT No open PDBs found|' "${set_pdbadmin_pw}"
+
+echo 'EXIT' | sqlplus -s / as sysdba @"${set_pdbadmin_pw}"
+
+echo 'Done setting PDBADMIN password in open PDBs'

--- a/OracleDatabase/19.3.0/scripts/setPassword.sh
+++ b/OracleDatabase/19.3.0/scripts/setPassword.sh
@@ -1,26 +1,54 @@
 #!/bin/bash
-# LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
-# 
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
 # Since: November, 2016
 # Author: gerald.venzl@oracle.com
-# Description: Sets the password for sys, system and pdb_admin
+# Description: Sets the password for sys, system and pdbadmin
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-# 
+#
+
+# Abort on any error
+set -Eeuo pipefail
 
 ORACLE_PWD=$1
-ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
-ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v pdbseed | awk '{print $9}' | cut -d/ -f6`"
-ORAENV_ASK=NO
-source oraenv
 
 sqlplus / as sysdba << EOF
-      ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
-      ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
-      ALTER SESSION SET CONTAINER=$ORACLE_PDB;
-      ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD";
-      exit;
+  ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
+  ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
 EOF
 
+echo 'Setting PDBADMIN password in open PDBs'
+
+set_pdbadmin_pw=$(mktemp)
+trap 'rm -f "${set_pdbadmin_pw}"' EXIT
+
+sqlplus -s / as sysdba > "${set_pdbadmin_pw}" << EOF
+  SET HEADING OFF LINESIZE 120 PAGESIZE 0
+  SELECT   'ALTER SESSION SET CONTAINER = ' || name || ';' || CHR(10)
+        || 'SET SERVEROUTPUT ON' || CHR(10)
+        || 'BEGIN' || CHR(10)
+        || '  EXECUTE IMMEDIATE ''ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD"'';' || CHR(10)
+        || '  DBMS_OUTPUT.PUT_LINE (''Set PDBADMIN password in ' || name || ' PDB'');' || CHR(10)
+        || 'EXCEPTION' || CHR(10)
+        || '  WHEN OTHERS THEN' || CHR(10)
+        || '    IF SQLCODE = -1918 THEN' || CHR(10)
+        || '      DBMS_OUTPUT.PUT_LINE (''PDBADMIN user not found in ' || name || ' PDB'');' || CHR(10)
+        || '    ELSE' || CHR(10)
+        || '      RAISE;' || CHR(10)
+        || '    END IF;' || CHR(10)
+        || 'END;' || CHR(10)
+        || '/'
+  FROM     v\$pdbs
+  WHERE    open_mode = 'READ WRITE'
+  ORDER BY name;
+EOF
+
+sed -i -e 's|no rows selected|PROMPT No open PDBs found|' "${set_pdbadmin_pw}"
+
+echo 'EXIT' | sqlplus -s / as sysdba @"${set_pdbadmin_pw}"
+
+echo 'Done setting PDBADMIN password in open PDBs'

--- a/OracleDatabase/21.3.0-XE/scripts/setPassword.sh
+++ b/OracleDatabase/21.3.0-XE/scripts/setPassword.sh
@@ -1,26 +1,54 @@
 #!/bin/bash
-# LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
-# 
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
 # Since: November, 2016
 # Author: gerald.venzl@oracle.com
-# Description: Sets the password for sys, system and pdb_admin
+# Description: Sets the password for sys, system and pdbadmin
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-# 
+#
+
+# Abort on any error
+set -Eeuo pipefail
 
 ORACLE_PWD=$1
-ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
-ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v pdbseed | awk '{print $9}' | cut -d/ -f6`"
-ORAENV_ASK=NO
-source oraenv
 
 sqlplus / as sysdba << EOF
-      ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
-      ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
-      ALTER SESSION SET CONTAINER=$ORACLE_PDB;
-      ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD";
-      exit;
+  ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
+  ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
 EOF
 
+echo 'Setting PDBADMIN password in open PDBs'
+
+set_pdbadmin_pw=$(mktemp)
+trap 'rm -f "${set_pdbadmin_pw}"' EXIT
+
+sqlplus -s / as sysdba > "${set_pdbadmin_pw}" << EOF
+  SET HEADING OFF LINESIZE 120 PAGESIZE 0
+  SELECT   'ALTER SESSION SET CONTAINER = ' || name || ';' || CHR(10)
+        || 'SET SERVEROUTPUT ON' || CHR(10)
+        || 'BEGIN' || CHR(10)
+        || '  EXECUTE IMMEDIATE ''ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD"'';' || CHR(10)
+        || '  DBMS_OUTPUT.PUT_LINE (''Set PDBADMIN password in ' || name || ' PDB'');' || CHR(10)
+        || 'EXCEPTION' || CHR(10)
+        || '  WHEN OTHERS THEN' || CHR(10)
+        || '    IF SQLCODE = -1918 THEN' || CHR(10)
+        || '      DBMS_OUTPUT.PUT_LINE (''PDBADMIN user not found in ' || name || ' PDB'');' || CHR(10)
+        || '    ELSE' || CHR(10)
+        || '      RAISE;' || CHR(10)
+        || '    END IF;' || CHR(10)
+        || 'END;' || CHR(10)
+        || '/'
+  FROM     v\$pdbs
+  WHERE    open_mode = 'READ WRITE'
+  ORDER BY name;
+EOF
+
+sed -i -e 's|no rows selected|PROMPT No open PDBs found|' "${set_pdbadmin_pw}"
+
+echo 'EXIT' | sqlplus -s / as sysdba @"${set_pdbadmin_pw}"
+
+echo 'Done setting PDBADMIN password in open PDBs'

--- a/OracleDatabase/21.3.0/scripts/setPassword.sh
+++ b/OracleDatabase/21.3.0/scripts/setPassword.sh
@@ -1,26 +1,54 @@
 #!/bin/bash
-# LICENSE UPL 1.0
 #
-# Copyright (c) 1982-2018 Oracle and/or its affiliates. All rights reserved.
-# 
+# Copyright (c) 2023 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
 # Since: November, 2016
 # Author: gerald.venzl@oracle.com
-# Description: Sets the password for sys, system and pdb_admin
+# Description: Sets the password for sys, system and pdbadmin
 #
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-# 
+#
+
+# Abort on any error
+set -Eeuo pipefail
 
 ORACLE_PWD=$1
-ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
-ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v pdbseed | awk '{print $9}' | cut -d/ -f6`"
-ORAENV_ASK=NO
-source oraenv
 
 sqlplus / as sysdba << EOF
-      ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
-      ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
-      ALTER SESSION SET CONTAINER=$ORACLE_PDB;
-      ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD";
-      exit;
+  ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
+  ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
 EOF
 
+echo 'Setting PDBADMIN password in open PDBs'
+
+set_pdbadmin_pw=$(mktemp)
+trap 'rm -f "${set_pdbadmin_pw}"' EXIT
+
+sqlplus -s / as sysdba > "${set_pdbadmin_pw}" << EOF
+  SET HEADING OFF LINESIZE 120 PAGESIZE 0
+  SELECT   'ALTER SESSION SET CONTAINER = ' || name || ';' || CHR(10)
+        || 'SET SERVEROUTPUT ON' || CHR(10)
+        || 'BEGIN' || CHR(10)
+        || '  EXECUTE IMMEDIATE ''ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD"'';' || CHR(10)
+        || '  DBMS_OUTPUT.PUT_LINE (''Set PDBADMIN password in ' || name || ' PDB'');' || CHR(10)
+        || 'EXCEPTION' || CHR(10)
+        || '  WHEN OTHERS THEN' || CHR(10)
+        || '    IF SQLCODE = -1918 THEN' || CHR(10)
+        || '      DBMS_OUTPUT.PUT_LINE (''PDBADMIN user not found in ' || name || ' PDB'');' || CHR(10)
+        || '    ELSE' || CHR(10)
+        || '      RAISE;' || CHR(10)
+        || '    END IF;' || CHR(10)
+        || 'END;' || CHR(10)
+        || '/'
+  FROM     v\$pdbs
+  WHERE    open_mode = 'READ WRITE'
+  ORDER BY name;
+EOF
+
+sed -i -e 's|no rows selected|PROMPT No open PDBs found|' "${set_pdbadmin_pw}"
+
+echo 'EXIT' | sqlplus -s / as sysdba @"${set_pdbadmin_pw}"
+
+echo 'Done setting PDBADMIN password in open PDBs'

--- a/OracleDatabase/23ai-Free/scripts/setPassword.sh
+++ b/OracleDatabase/23ai-Free/scripts/setPassword.sh
@@ -11,17 +11,44 @@
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 #
 
+# Abort on any error
+set -Eeuo pipefail
+
 ORACLE_PWD=$1
-ORACLE_SID="`grep $ORACLE_HOME /etc/oratab | cut -d: -f1`"
-ORACLE_PDB="`ls -dl $ORACLE_BASE/oradata/$ORACLE_SID/*/ | grep -v pdbseed | awk '{print $9}' | cut -d/ -f6`"
-ORAENV_ASK=NO
-source oraenv
 
 sqlplus / as sysdba << EOF
-      ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
-      ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
-      ALTER SESSION SET CONTAINER=$ORACLE_PDB;
-      ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD";
-      exit;
+  ALTER USER SYS IDENTIFIED BY "$ORACLE_PWD";
+  ALTER USER SYSTEM IDENTIFIED BY "$ORACLE_PWD";
 EOF
 
+echo 'Setting PDBADMIN password in open PDBs'
+
+set_pdbadmin_pw=$(mktemp)
+trap 'rm -f "${set_pdbadmin_pw}"' EXIT
+
+sqlplus -s / as sysdba > "${set_pdbadmin_pw}" << EOF
+  SET HEADING OFF LINESIZE 120 PAGESIZE 0
+  SELECT   'ALTER SESSION SET CONTAINER = ' || name || ';' || CHR(10)
+        || 'SET SERVEROUTPUT ON' || CHR(10)
+        || 'BEGIN' || CHR(10)
+        || '  EXECUTE IMMEDIATE ''ALTER USER PDBADMIN IDENTIFIED BY "$ORACLE_PWD"'';' || CHR(10)
+        || '  DBMS_OUTPUT.PUT_LINE (''Set PDBADMIN password in ' || name || ' PDB'');' || CHR(10)
+        || 'EXCEPTION' || CHR(10)
+        || '  WHEN OTHERS THEN' || CHR(10)
+        || '    IF SQLCODE = -1918 THEN' || CHR(10)
+        || '      DBMS_OUTPUT.PUT_LINE (''PDBADMIN user not found in ' || name || ' PDB'');' || CHR(10)
+        || '    ELSE' || CHR(10)
+        || '      RAISE;' || CHR(10)
+        || '    END IF;' || CHR(10)
+        || 'END;' || CHR(10)
+        || '/'
+  FROM     v\$pdbs
+  WHERE    open_mode = 'READ WRITE'
+  ORDER BY name;
+EOF
+
+sed -i -e 's|no rows selected|PROMPT No open PDBs found|' "${set_pdbadmin_pw}"
+
+echo 'EXIT' | sqlplus -s / as sysdba @"${set_pdbadmin_pw}"
+
+echo 'Done setting PDBADMIN password in open PDBs'


### PR DESCRIPTION
Modify the `setPassword.sh` script for all single-instance database projects (except 11g XE) to correctly set the PDBADMIN password when one or more PDBs have been added.

The updated script is identical for all 8 affected projects. Instead of parsing the directory names under `$ORACLE_BASE/oradata/$ORACLE_SID` to find the name of the PDB (which doesn't work when there are multiple PDBs), it queries `v$pdbs` and creates a PL/SQL script that sets the PDBADMIN password in all open PDBs.

Tested with both VirtualBox and libvirt providers.

Fixes #295

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>