### PR TITLE
DB projects - optionally use YAML for configuration

### DIFF
--- a/OracleDatabase/11.2.0.2/.gitignore
+++ b/OracleDatabase/11.2.0.2/.gitignore
@@ -1,1 +1,1 @@
-.env.local*
+config.local*.yaml

--- a/OracleDatabase/11.2.0.2/README.md
+++ b/OracleDatabase/11.2.0.2/README.md
@@ -4,9 +4,7 @@ This Vagrant project provisions Oracle Database automatically, using Vagrant, an
 
 ## Prerequisites
 
-1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
-2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
-makes configuration much easier
+Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
 
 ## Getting started
 
@@ -53,14 +51,13 @@ There are three ways to set parameters:
 
 1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
 2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
-3. Use the `.env`/`.env.local` files (requires
-[vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
+3. Use the `config.yaml`/`config.local.yaml` files. You can configure your installation by editing the `config.yaml` file, but `config.yaml` will be overwritten on updates, so it's better to make a copy of `config.yaml` called `config.local.yaml`, then make changes in `config.local.yaml`. The `config.local.yaml` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
 
 Parameters are considered in the following order (first one wins):
 
 1. Environment variables
-2. `.env.local` (if it exists and the  [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
-3. `.env` (if the [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
+2. `config.local.yaml` (if it exists)
+3. `config.yaml`
 4. `Vagrantfile` definitions
 
 ### VM parameters
@@ -78,12 +75,10 @@ Parameters are considered in the following order (first one wins):
 * `VM_LISTENER_PORT` (default: `1521`): Listener port.
 * `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS and SYSTEM accounts.
 
-## Optional plugins
+## Optional plugin
 
-When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+When installed, this Vagrant project will make use of the following third party Vagrant plugin:
 
-* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
-variables from .env files;
 * [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
 proxies in the guest VM if you need to access the Internet through a proxy. See
 the plugin documentation for configuration.

--- a/OracleDatabase/11.2.0.2/Vagrantfile
+++ b/OracleDatabase/11.2.0.2/Vagrantfile
@@ -6,8 +6,7 @@
 # Since: January, 2018
 # Author: gerald.venzl@oracle.com
 # Description: Creates an Oracle database Vagrant virtual machine.
-# Optional plugins:
-#     vagrant-env (use .env files for configuration)
+# Optional plugin:
 #     vagrant-proxyconf (if you don't have direct access to the Internet)
 #         see https://github.com/tmatilai/vagrant-proxyconf for configuration
 #
@@ -16,6 +15,7 @@
 
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+require 'yaml'
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
@@ -29,9 +29,13 @@ ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
 
 # Define constants
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # Use vagrant-env plugin if available
-  if Vagrant.has_plugin?("vagrant-env")
-    config.env.load(".env.local", ".env") # enable the plugin
+  # Load configuration parameters into environment
+  ['config.local.yaml', 'config.yaml'].each do |f|
+    cfg = File.file?(f) ? YAML.safe_load_file(f, freeze: true) : {}
+    cfg && cfg.each do |key, value|
+      key = key.upcase
+      (!ENV[key] || ENV[key].empty?) && ENV[key] = value.to_s
+    end
   end
 
   # VM name

--- a/OracleDatabase/11.2.0.2/config.yaml
+++ b/OracleDatabase/11.2.0.2/config.yaml
@@ -1,28 +1,27 @@
+---
 # Oracle Database 11.2.0.2 Express Edition configuration file
 #
-# Requires vagrant-env plugin
-#
-# This file will be overwritten on updates, so it is recommended to make
-# a copy of this file called .env.local, then make changes in .env.local.
+# This file will be overwritten on updates, so it is recommended to make a copy
+# of this file called config.local.yaml, then make changes in config.local.yaml.
 #
 # To change a parameter, uncomment it and set it to the desired value.
 # All commented parameters will retain their default values.
 
 # VM name
-# VM_NAME='oracle11g-xe-vagrant'
+#VM_NAME: 'oracle11g-xe-vagrant'
 
 # Memory for the VM (in MB, 2048 MB = 2 GB)
-# VM_MEMORY=2048
+#VM_MEMORY: 2048
 
 # VM time zone
 # If not specified, will be set to match host time zone (if possible)
 # Can use time zone name (e.g., 'America/Los_Angeles')
 # or an offset from GMT (e.g., 'Etc/GMT-2')
-# VM_SYSTEM_TIMEZONE=
+#VM_SYSTEM_TIMEZONE: ''
 
 # Listener port
-# VM_LISTENER_PORT=1521
+#VM_LISTENER_PORT: 1521
 
 # Oracle Database password for SYS and SYSTEM accounts
 # If left blank, the password will be generated automatically
-# VM_ORACLE_PWD=
+#VM_ORACLE_PWD: ''

--- a/OracleDatabase/12.1.0.2/.gitignore
+++ b/OracleDatabase/12.1.0.2/.gitignore
@@ -1,1 +1,1 @@
-.env.local*
+config.local*.yaml

--- a/OracleDatabase/12.1.0.2/README.md
+++ b/OracleDatabase/12.1.0.2/README.md
@@ -4,9 +4,7 @@ This Vagrant project provisions Oracle Database automatically, using Vagrant, an
 
 ## Prerequisites
 
-1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
-2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
-makes configuration much easier
+Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
 
 ## Getting started
 
@@ -57,14 +55,13 @@ There are three ways to set parameters:
 
 1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
 2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
-3. Use the `.env`/`.env.local` files (requires
-[vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
+3. Use the `config.yaml`/`config.local.yaml` files. You can configure your installation by editing the `config.yaml` file, but `config.yaml` will be overwritten on updates, so it's better to make a copy of `config.yaml` called `config.local.yaml`, then make changes in `config.local.yaml`. The `config.local.yaml` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
 
 Parameters are considered in the following order (first one wins):
 
 1. Environment variables
-2. `.env.local` (if it exists and the  [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
-3. `.env` (if the [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
+2. `config.local.yaml` (if it exists)
+3. `config.yaml`
 4. `Vagrantfile` definitions
 
 ### VM parameters
@@ -89,12 +86,10 @@ Parameters are considered in the following order (first one wins):
 * `VM_EM_EXPRESS_PORT` (default: `5500`): EM Express port.
 * `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS, SYSTEM and PDBADMIN accounts.
 
-## Optional plugins
+## Optional plugin
 
-When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+When installed, this Vagrant project will make use of the following third party Vagrant plugin:
 
-* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
-variables from .env files;
 * [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
 proxies in the guest VM if you need to access the Internet through a proxy. See
 the plugin documentation for configuration.

--- a/OracleDatabase/12.1.0.2/Vagrantfile
+++ b/OracleDatabase/12.1.0.2/Vagrantfile
@@ -6,8 +6,7 @@
 # Since: January, 2018
 # Author: gerald.venzl@oracle.com
 # Description: Creates an Oracle database Vagrant virtual machine.
-# Optional plugins:
-#     vagrant-env (use .env files for configuration)
+# Optional plugin:
 #     vagrant-proxyconf (if you don't have direct access to the Internet)
 #         see https://github.com/tmatilai/vagrant-proxyconf for configuration
 #
@@ -16,6 +15,7 @@
 
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+require 'yaml'
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
@@ -29,9 +29,13 @@ ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
 
 # Define constants
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # Use vagrant-env plugin if available
-  if Vagrant.has_plugin?("vagrant-env")
-    config.env.load(".env.local", ".env") # enable the plugin
+  # Load configuration parameters into environment
+  ['config.local.yaml', 'config.yaml'].each do |f|
+    cfg = File.file?(f) ? YAML.safe_load_file(f, freeze: true) : {}
+    cfg && cfg.each do |key, value|
+      key = key.upcase
+      (!ENV[key] || ENV[key].empty?) && ENV[key] = value.to_s
+    end
   end
 
   # VM name

--- a/OracleDatabase/12.1.0.2/config.yaml
+++ b/OracleDatabase/12.1.0.2/config.yaml
@@ -1,50 +1,49 @@
+---
 # Oracle Database 12.1.0.2 configuration file
 #
-# Requires vagrant-env plugin
-#
-# This file will be overwritten on updates, so it is recommended to make
-# a copy of this file called .env.local, then make changes in .env.local.
+# This file will be overwritten on updates, so it is recommended to make a copy
+# of this file called config.local.yaml, then make changes in config.local.yaml.
 #
 # To change a parameter, uncomment it and set it to the desired value.
 # All commented parameters will retain their default values.
 
 # VM name
-# VM_NAME='oracle-12102-vagrant'
+#VM_NAME: 'oracle-12102-vagrant'
 
 # Memory for the VM (in MB, 2048 MB = 2 GB)
-# VM_MEMORY=2048
+#VM_MEMORY: 2048
 
 # VM time zone
 # If not specified, will be set to match host time zone (if possible)
 # Can use time zone name (e.g., 'America/Los_Angeles')
 # or an offset from GMT (e.g., 'Etc/GMT-2')
-# VM_SYSTEM_TIMEZONE=
+#VM_SYSTEM_TIMEZONE: ''
 
 # Oracle base directory
-# VM_ORACLE_BASE='/opt/oracle'
+#VM_ORACLE_BASE: '/opt/oracle'
 
 # Oracle home directory
-# VM_ORACLE_HOME='/opt/oracle/product/12.1.0.2/dbhome_1'
+#VM_ORACLE_HOME: '/opt/oracle/product/12.1.0.2/dbhome_1'
 
 # Oracle SID
-# VM_ORACLE_SID='ORCLCDB'
+#VM_ORACLE_SID: 'ORCLCDB'
 
 # PDB name
-# VM_ORACLE_PDB='ORCLPDB1'
+#VM_ORACLE_PDB: 'ORCLPDB1'
 
 # Database character set
-# VM_ORACLE_CHARACTERSET='AL32UTF8'
+#VM_ORACLE_CHARACTERSET: 'AL32UTF8'
 
 # Oracle Database edition
 # Valid values are 'EE' for Enterprise Edition or 'SE2' for Standard Edition 2
-# VM_ORACLE_EDITION='EE'
+#VM_ORACLE_EDITION: 'EE'
 
 # Listener port
-# VM_LISTENER_PORT=1521
+#VM_LISTENER_PORT: 1521
 
 # EM Express port
-# VM_EM_EXPRESS_PORT=5500
+#VM_EM_EXPRESS_PORT: 5500
 
 # Oracle Database password for SYS, SYSTEM and PDBADMIN accounts
 # If left blank, the password will be generated automatically
-# VM_ORACLE_PWD=
+#VM_ORACLE_PWD: ''

--- a/OracleDatabase/12.2.0.1/.gitignore
+++ b/OracleDatabase/12.2.0.1/.gitignore
@@ -1,1 +1,1 @@
-.env.local*
+config.local*.yaml

--- a/OracleDatabase/12.2.0.1/README.md
+++ b/OracleDatabase/12.2.0.1/README.md
@@ -4,9 +4,7 @@ This Vagrant project provisions Oracle Database automatically, using Vagrant, an
 
 ## Prerequisites
 
-1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
-2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
-makes configuration much easier
+Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
 
 ## Getting started
 
@@ -55,14 +53,13 @@ There are three ways to set parameters:
 
 1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
 2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
-3. Use the `.env`/`.env.local` files (requires
-[vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
+3. Use the `config.yaml`/`config.local.yaml` files. You can configure your installation by editing the `config.yaml` file, but `config.yaml` will be overwritten on updates, so it's better to make a copy of `config.yaml` called `config.local.yaml`, then make changes in `config.local.yaml`. The `config.local.yaml` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
 
 Parameters are considered in the following order (first one wins):
 
 1. Environment variables
-2. `.env.local` (if it exists and the  [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
-3. `.env` (if the [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
+2. `config.local.yaml` (if it exists)
+3. `config.yaml`
 4. `Vagrantfile` definitions
 
 ### VM parameters
@@ -87,12 +84,10 @@ Parameters are considered in the following order (first one wins):
 * `VM_EM_EXPRESS_PORT` (default: `5500`): EM Express port.
 * `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS, SYSTEM and PDBADMIN accounts.
 
-## Optional plugins
+## Optional plugin
 
-When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+When installed, this Vagrant project will make use of the following third party Vagrant plugin:
 
-* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
-variables from .env files;
 * [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
 proxies in the guest VM if you need to access the Internet through a proxy. See
 the plugin documentation for configuration.

--- a/OracleDatabase/12.2.0.1/Vagrantfile
+++ b/OracleDatabase/12.2.0.1/Vagrantfile
@@ -6,8 +6,7 @@
 # Since: January, 2018
 # Author: gerald.venzl@oracle.com
 # Description: Creates an Oracle database Vagrant virtual machine.
-# Optional plugins:
-#     vagrant-env (use .env files for configuration)
+# Optional plugin:
 #     vagrant-proxyconf (if you don't have direct access to the Internet)
 #         see https://github.com/tmatilai/vagrant-proxyconf for configuration
 #
@@ -16,6 +15,7 @@
 
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+require 'yaml'
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
@@ -29,9 +29,13 @@ ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
 
 # Define constants
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # Use vagrant-env plugin if available
-  if Vagrant.has_plugin?("vagrant-env")
-    config.env.load(".env.local", ".env") # enable the plugin
+  # Load configuration parameters into environment
+  ['config.local.yaml', 'config.yaml'].each do |f|
+    cfg = File.file?(f) ? YAML.safe_load_file(f, freeze: true) : {}
+    cfg && cfg.each do |key, value|
+      key = key.upcase
+      (!ENV[key] || ENV[key].empty?) && ENV[key] = value.to_s
+    end
   end
 
   # VM name

--- a/OracleDatabase/12.2.0.1/config.yaml
+++ b/OracleDatabase/12.2.0.1/config.yaml
@@ -1,50 +1,49 @@
-# Oracle Database 18.3.0 configuration file
+---
+# Oracle Database 12.2.0.1 configuration file
 #
-# Requires vagrant-env plugin
-#
-# This file will be overwritten on updates, so it is recommended to make
-# a copy of this file called .env.local, then make changes in .env.local.
+# This file will be overwritten on updates, so it is recommended to make a copy
+# of this file called config.local.yaml, then make changes in config.local.yaml.
 #
 # To change a parameter, uncomment it and set it to the desired value.
 # All commented parameters will retain their default values.
 
 # VM name
-# VM_NAME='oracle-18c-vagrant'
+#VM_NAME: 'oracle-12201-vagrant'
 
-# Memory for the VM (in MB, 2300 MB is ~2.25 GB)
-# VM_MEMORY=2300
+# Memory for the VM (in MB, 2048 MB = 2 GB)
+#VM_MEMORY: 2048
 
 # VM time zone
 # If not specified, will be set to match host time zone (if possible)
 # Can use time zone name (e.g., 'America/Los_Angeles')
 # or an offset from GMT (e.g., 'Etc/GMT-2')
-# VM_SYSTEM_TIMEZONE=
+#VM_SYSTEM_TIMEZONE: ''
 
 # Oracle base directory
-# VM_ORACLE_BASE='/opt/oracle'
+#VM_ORACLE_BASE: '/opt/oracle'
 
 # Oracle home directory
-# VM_ORACLE_HOME='/opt/oracle/product/18c/dbhome_1'
+#VM_ORACLE_HOME: '/opt/oracle/product/12.2.0.1/dbhome_1'
 
 # Oracle SID
-# VM_ORACLE_SID='ORCLCDB'
+#VM_ORACLE_SID: 'ORCLCDB'
 
 # PDB name
-# VM_ORACLE_PDB='ORCLPDB1'
+#VM_ORACLE_PDB: 'ORCLPDB1'
 
 # Database character set
-# VM_ORACLE_CHARACTERSET='AL32UTF8'
+#VM_ORACLE_CHARACTERSET: 'AL32UTF8'
 
 # Oracle Database edition
 # Valid values are 'EE' for Enterprise Edition or 'SE2' for Standard Edition 2
-# VM_ORACLE_EDITION='EE'
+#VM_ORACLE_EDITION: 'EE'
 
 # Listener port
-# VM_LISTENER_PORT=1521
+#VM_LISTENER_PORT: 1521
 
 # EM Express port
-# VM_EM_EXPRESS_PORT=5500
+#VM_EM_EXPRESS_PORT: 5500
 
 # Oracle Database password for SYS, SYSTEM and PDBADMIN accounts
 # If left blank, the password will be generated automatically
-# VM_ORACLE_PWD=
+#VM_ORACLE_PWD: ''

--- a/OracleDatabase/18.3.0/.gitignore
+++ b/OracleDatabase/18.3.0/.gitignore
@@ -1,1 +1,1 @@
-.env.local*
+config.local*.yaml

--- a/OracleDatabase/18.3.0/README.md
+++ b/OracleDatabase/18.3.0/README.md
@@ -4,9 +4,7 @@ This Vagrant project provisions Oracle Database automatically, using Vagrant, an
 
 ## Prerequisites
 
-1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
-2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
-makes configuration much easier
+Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
 
 ## Getting started
 
@@ -55,14 +53,13 @@ There are three ways to set parameters:
 
 1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
 2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
-3. Use the `.env`/`.env.local` files (requires
-[vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
+3. Use the `config.yaml`/`config.local.yaml` files. You can configure your installation by editing the `config.yaml` file, but `config.yaml` will be overwritten on updates, so it's better to make a copy of `config.yaml` called `config.local.yaml`, then make changes in `config.local.yaml`. The `config.local.yaml` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
 
 Parameters are considered in the following order (first one wins):
 
 1. Environment variables
-2. `.env.local` (if it exists and the  [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
-3. `.env` (if the [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
+2. `config.local.yaml` (if it exists)
+3. `config.yaml`
 4. `Vagrantfile` definitions
 
 ### VM parameters
@@ -87,12 +84,10 @@ Parameters are considered in the following order (first one wins):
 * `VM_EM_EXPRESS_PORT` (default: `5500`): EM Express port.
 * `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS, SYSTEM and PDBADMIN accounts.
 
-## Optional plugins
+## Optional plugin
 
-When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+When installed, this Vagrant project will make use of the following third party Vagrant plugin:
 
-* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
-variables from .env files;
 * [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
 proxies in the guest VM if you need to access the Internet through a proxy. See
 the plugin documentation for configuration.

--- a/OracleDatabase/18.3.0/Vagrantfile
+++ b/OracleDatabase/18.3.0/Vagrantfile
@@ -6,8 +6,7 @@
 # Since: July, 2018
 # Author: gerald.venzl@oracle.com
 # Description: Creates an Oracle database Vagrant virtual machine.
-# Optional plugins:
-#     vagrant-env (use .env files for configuration)
+# Optional plugin:
 #     vagrant-proxyconf (if you don't have direct access to the Internet)
 #         see https://github.com/tmatilai/vagrant-proxyconf for configuration
 #
@@ -16,6 +15,7 @@
 
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+require 'yaml'
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
@@ -29,9 +29,13 @@ ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
 
 # Define constants
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # Use vagrant-env plugin if available
-  if Vagrant.has_plugin?("vagrant-env")
-    config.env.load(".env.local", ".env") # enable the plugin
+  # Load configuration parameters into environment
+  ['config.local.yaml', 'config.yaml'].each do |f|
+    cfg = File.file?(f) ? YAML.safe_load_file(f, freeze: true) : {}
+    cfg && cfg.each do |key, value|
+      key = key.upcase
+      (!ENV[key] || ENV[key].empty?) && ENV[key] = value.to_s
+    end
   end
 
   # VM name

--- a/OracleDatabase/18.3.0/config.yaml
+++ b/OracleDatabase/18.3.0/config.yaml
@@ -1,50 +1,49 @@
-# Oracle Database 21.3.0 configuration file
+---
+# Oracle Database 18.3.0 configuration file
 #
-# Requires vagrant-env plugin
-#
-# This file will be overwritten on updates, so it is recommended to make
-# a copy of this file called .env.local, then make changes in .env.local.
+# This file will be overwritten on updates, so it is recommended to make a copy
+# of this file called config.local.yaml, then make changes in config.local.yaml.
 #
 # To change a parameter, uncomment it and set it to the desired value.
 # All commented parameters will retain their default values.
 
 # VM name
-# VM_NAME='oracle-21c-vagrant'
+#VM_NAME: 'oracle-18c-vagrant'
 
-# Memory for the VM (in MB, 2560 MB = 2.5 GB)
-# VM_MEMORY=2560
+# Memory for the VM (in MB, 2300 MB is ~2.25 GB)
+#VM_MEMORY: 2300
 
 # VM time zone
 # If not specified, will be set to match host time zone (if possible)
 # Can use time zone name (e.g., 'America/Los_Angeles')
 # or an offset from GMT (e.g., 'Etc/GMT-2')
-# VM_SYSTEM_TIMEZONE=
+#VM_SYSTEM_TIMEZONE: ''
 
 # Oracle base directory
-# VM_ORACLE_BASE='/opt/oracle'
+#VM_ORACLE_BASE: '/opt/oracle'
 
 # Oracle home directory
-# VM_ORACLE_HOME='/opt/oracle/product/21c/dbhome_1'
+#VM_ORACLE_HOME: '/opt/oracle/product/18c/dbhome_1'
 
 # Oracle SID
-# VM_ORACLE_SID='ORCLCDB'
+#VM_ORACLE_SID: 'ORCLCDB'
 
 # PDB name
-# VM_ORACLE_PDB='ORCLPDB1'
+#VM_ORACLE_PDB: 'ORCLPDB1'
 
 # Database character set
-# VM_ORACLE_CHARACTERSET='AL32UTF8'
+#VM_ORACLE_CHARACTERSET: 'AL32UTF8'
 
 # Oracle Database edition
 # Valid values are 'EE' for Enterprise Edition or 'SE2' for Standard Edition 2
-# VM_ORACLE_EDITION='EE'
+#VM_ORACLE_EDITION: 'EE'
 
 # Listener port
-# VM_LISTENER_PORT=1521
+#VM_LISTENER_PORT: 1521
 
 # EM Express port
-# VM_EM_EXPRESS_PORT=5500
+#VM_EM_EXPRESS_PORT: 5500
 
 # Oracle Database password for SYS, SYSTEM and PDBADMIN accounts
 # If left blank, the password will be generated automatically
-# VM_ORACLE_PWD=
+#VM_ORACLE_PWD: ''

--- a/OracleDatabase/18.4.0-XE/.gitignore
+++ b/OracleDatabase/18.4.0-XE/.gitignore
@@ -1,2 +1,2 @@
 *.rpm
-.env.local*
+config.local*.yaml

--- a/OracleDatabase/18.4.0-XE/README.md
+++ b/OracleDatabase/18.4.0-XE/README.md
@@ -4,9 +4,7 @@ This Vagrant project provisions Oracle Database automatically, using Vagrant, an
 
 ## Prerequisites
 
-1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
-2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
-makes configuration much easier
+Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
 
 ## Getting started
 
@@ -53,14 +51,13 @@ There are three ways to set parameters:
 
 1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
 2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
-3. Use the `.env`/`.env.local` files (requires
-[vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
+3. Use the `config.yaml`/`config.local.yaml` files. You can configure your installation by editing the `config.yaml` file, but `config.yaml` will be overwritten on updates, so it's better to make a copy of `config.yaml` called `config.local.yaml`, then make changes in `config.local.yaml`. The `config.local.yaml` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
 
 Parameters are considered in the following order (first one wins):
 
 1. Environment variables
-2. `.env.local` (if it exists and the  [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
-3. `.env` (if the [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
+2. `config.local.yaml` (if it exists)
+3. `config.yaml`
 4. `Vagrantfile` definitions
 
 ### VM parameters
@@ -81,12 +78,10 @@ Parameters are considered in the following order (first one wins):
 * `VM_EM_EXPRESS_PORT` (default: `5500`): EM Express port.
 * `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS, SYSTEM and PDBADMIN accounts.
 
-## Optional plugins
+## Optional plugin
 
-When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+When installed, this Vagrant project will make use of the following third party Vagrant plugin:
 
-* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
-variables from .env files;
 * [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
 proxies in the guest VM if you need to access the Internet through a proxy. See
 the plugin documentation for configuration.

--- a/OracleDatabase/18.4.0-XE/Vagrantfile
+++ b/OracleDatabase/18.4.0-XE/Vagrantfile
@@ -6,8 +6,7 @@
 # Since: July, 2018
 # Author: gerald.venzl@oracle.com
 # Description: Creates an Oracle database Vagrant virtual machine.
-# Optional plugins:
-#     vagrant-env (use .env files for configuration)
+# Optional plugin:
 #     vagrant-proxyconf (if you don't have direct access to the Internet)
 #         see https://github.com/tmatilai/vagrant-proxyconf for configuration
 #
@@ -16,6 +15,7 @@
 
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+require 'yaml'
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
@@ -29,9 +29,13 @@ ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
 
 # Define constants
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # Use vagrant-env plugin if available
-  if Vagrant.has_plugin?("vagrant-env")
-    config.env.load(".env.local", ".env") # enable the plugin
+  # Load configuration parameters into environment
+  ['config.local.yaml', 'config.yaml'].each do |f|
+    cfg = File.file?(f) ? YAML.safe_load_file(f, freeze: true) : {}
+    cfg && cfg.each do |key, value|
+      key = key.upcase
+      (!ENV[key] || ENV[key].empty?) && ENV[key] = value.to_s
+    end
   end
 
   # VM name

--- a/OracleDatabase/18.4.0-XE/config.yaml
+++ b/OracleDatabase/18.4.0-XE/config.yaml
@@ -1,37 +1,36 @@
+---
 # Oracle Database 18.4.0 Express Edition configuration file
 #
-# Requires vagrant-env plugin
-#
-# This file will be overwritten on updates, so it is recommended to make
-# a copy of this file called .env.local, then make changes in .env.local.
+# This file will be overwritten on updates, so it is recommended to make a copy
+# of this file called config.local.yaml, then make changes in config.local.yaml.
 #
 # To change a parameter, uncomment it and set it to the desired value.
 # All commented parameters will retain their default values.
 
 # VM name
-# VM_NAME='oracle18c-xe-vagrant'
+#VM_NAME: 'oracle18c-xe-vagrant'
 
 # Memory for the VM (in MB, 2048 MB = 2 GB)
-# VM_MEMORY=2048
+#VM_MEMORY: 2048
 
 # VM time zone
 # If not specified, will be set to match host time zone (if possible)
 # Can use time zone name (e.g., 'America/Los_Angeles')
 # or an offset from GMT (e.g., 'Etc/GMT-2')
-# VM_SYSTEM_TIMEZONE=
+#VM_SYSTEM_TIMEZONE: ''
 
 # Save database installer RPM file for reuse when VM is rebuilt
-# VM_KEEP_DB_INSTALLER=false
+#VM_KEEP_DB_INSTALLER: false
 
 # Database character set
-# VM_ORACLE_CHARACTERSET='AL32UTF8'
+#VM_ORACLE_CHARACTERSET: 'AL32UTF8'
 
 # Listener port
-# VM_LISTENER_PORT=1521
+#VM_LISTENER_PORT: 1521
 
 # EM Express port
-# VM_EM_EXPRESS_PORT=5500
+#VM_EM_EXPRESS_PORT: 5500
 
 # Oracle Database password for SYS, SYSTEM and PDBADMIN accounts
 # If left blank, the password will be generated automatically
-# VM_ORACLE_PWD=
+#VM_ORACLE_PWD: ''

--- a/OracleDatabase/19.3.0/.gitignore
+++ b/OracleDatabase/19.3.0/.gitignore
@@ -1,1 +1,1 @@
-.env.local*
+config.local*.yaml

--- a/OracleDatabase/19.3.0/README.md
+++ b/OracleDatabase/19.3.0/README.md
@@ -4,9 +4,7 @@ This Vagrant project provisions Oracle Database automatically, using Vagrant, an
 
 ## Prerequisites
 
-1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
-2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
-makes configuration much easier
+Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
 
 ## Getting started
 
@@ -55,14 +53,13 @@ There are three ways to set parameters:
 
 1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
 2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
-3. Use the `.env`/`.env.local` files (requires
-[vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
+3. Use the `config.yaml`/`config.local.yaml` files. You can configure your installation by editing the `config.yaml` file, but `config.yaml` will be overwritten on updates, so it's better to make a copy of `config.yaml` called `config.local.yaml`, then make changes in `config.local.yaml`. The `config.local.yaml` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
 
 Parameters are considered in the following order (first one wins):
 
 1. Environment variables
-2. `.env.local` (if it exists and the  [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
-3. `.env` (if the [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
+2. `config.local.yaml` (if it exists)
+3. `config.yaml`
 4. `Vagrantfile` definitions
 
 ### VM parameters
@@ -87,12 +84,10 @@ Parameters are considered in the following order (first one wins):
 * `VM_EM_EXPRESS_PORT` (default: `5500`): EM Express port.
 * `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS, SYSTEM and PDBADMIN accounts.
 
-## Optional plugins
+## Optional plugin
 
-When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+When installed, this Vagrant project will make use of the following third party Vagrant plugin:
 
-* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
-variables from .env files;
 * [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
 proxies in the guest VM if you need to access the Internet through a proxy. See
 the plugin documentation for configuration.

--- a/OracleDatabase/19.3.0/Vagrantfile
+++ b/OracleDatabase/19.3.0/Vagrantfile
@@ -6,8 +6,7 @@
 # Since: July, 2018
 # Author: gerald.venzl@oracle.com
 # Description: Creates an Oracle database Vagrant virtual machine.
-# Optional plugins:
-#     vagrant-env (use .env files for configuration)
+# Optional plugin:
 #     vagrant-proxyconf (if you don't have direct access to the Internet)
 #         see https://github.com/tmatilai/vagrant-proxyconf for configuration
 #
@@ -16,6 +15,7 @@
 
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+require 'yaml'
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
@@ -29,9 +29,13 @@ ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
 
 # Define constants
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # Use vagrant-env plugin if available
-  if Vagrant.has_plugin?("vagrant-env")
-    config.env.load(".env.local", ".env") # enable the plugin
+  # Load configuration parameters into environment
+  ['config.local.yaml', 'config.yaml'].each do |f|
+    cfg = File.file?(f) ? YAML.safe_load_file(f, freeze: true) : {}
+    cfg && cfg.each do |key, value|
+      key = key.upcase
+      (!ENV[key] || ENV[key].empty?) && ENV[key] = value.to_s
+    end
   end
 
   # VM name

--- a/OracleDatabase/19.3.0/config.yaml
+++ b/OracleDatabase/19.3.0/config.yaml
@@ -1,50 +1,49 @@
+---
 # Oracle Database 19.3.0 configuration file
 #
-# Requires vagrant-env plugin
-#
-# This file will be overwritten on updates, so it is recommended to make
-# a copy of this file called .env.local, then make changes in .env.local.
+# This file will be overwritten on updates, so it is recommended to make a copy
+# of this file called config.local.yaml, then make changes in config.local.yaml.
 #
 # To change a parameter, uncomment it and set it to the desired value.
 # All commented parameters will retain their default values.
 
 # VM name
-# VM_NAME='oracle-19c-vagrant'
+#VM_NAME: 'oracle-19c-vagrant'
 
 # Memory for the VM (in MB, 2300 MB is ~2.25 GB)
-# VM_MEMORY=2300
+#VM_MEMORY: 2300
 
 # VM time zone
 # If not specified, will be set to match host time zone (if possible)
 # Can use time zone name (e.g., 'America/Los_Angeles')
 # or an offset from GMT (e.g., 'Etc/GMT-2')
-# VM_SYSTEM_TIMEZONE=
+#VM_SYSTEM_TIMEZONE: ''
 
 # Oracle base directory
-# VM_ORACLE_BASE='/opt/oracle'
+#VM_ORACLE_BASE: '/opt/oracle'
 
 # Oracle home directory
-# VM_ORACLE_HOME='/opt/oracle/product/19c/dbhome_1'
+#VM_ORACLE_HOME: '/opt/oracle/product/19c/dbhome_1'
 
 # Oracle SID
-# VM_ORACLE_SID='ORCLCDB'
+#VM_ORACLE_SID: 'ORCLCDB'
 
 # PDB name
-# VM_ORACLE_PDB='ORCLPDB1'
+#VM_ORACLE_PDB: 'ORCLPDB1'
 
 # Database character set
-# VM_ORACLE_CHARACTERSET='AL32UTF8'
+#VM_ORACLE_CHARACTERSET: 'AL32UTF8'
 
 # Oracle Database edition
 # Valid values are 'EE' for Enterprise Edition or 'SE2' for Standard Edition 2
-# VM_ORACLE_EDITION='EE'
+#VM_ORACLE_EDITION: 'EE'
 
 # Listener port
-# VM_LISTENER_PORT=1521
+#VM_LISTENER_PORT: 1521
 
 # EM Express port
-# VM_EM_EXPRESS_PORT=5500
+#VM_EM_EXPRESS_PORT: 5500
 
 # Oracle Database password for SYS, SYSTEM and PDBADMIN accounts
 # If left blank, the password will be generated automatically
-# VM_ORACLE_PWD=
+#VM_ORACLE_PWD: ''

--- a/OracleDatabase/21.3.0-XE/.gitignore
+++ b/OracleDatabase/21.3.0-XE/.gitignore
@@ -1,2 +1,2 @@
 *.rpm
-.env.local*
+config.local*.yaml

--- a/OracleDatabase/21.3.0-XE/README.md
+++ b/OracleDatabase/21.3.0-XE/README.md
@@ -4,9 +4,7 @@ This Vagrant project provisions Oracle Database automatically, using Vagrant, an
 
 ## Prerequisites
 
-1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
-2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
-makes configuration much easier
+Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
 
 ## Getting started
 
@@ -53,14 +51,13 @@ There are three ways to set parameters:
 
 1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
 2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
-3. Use the `.env`/`.env.local` files (requires
-[vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
+3. Use the `config.yaml`/`config.local.yaml` files. You can configure your installation by editing the `config.yaml` file, but `config.yaml` will be overwritten on updates, so it's better to make a copy of `config.yaml` called `config.local.yaml`, then make changes in `config.local.yaml`. The `config.local.yaml` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
 
 Parameters are considered in the following order (first one wins):
 
 1. Environment variables
-2. `.env.local` (if it exists and the  [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
-3. `.env` (if the [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
+2. `config.local.yaml` (if it exists)
+3. `config.yaml`
 4. `Vagrantfile` definitions
 
 ### VM parameters
@@ -81,12 +78,10 @@ Parameters are considered in the following order (first one wins):
 * `VM_EM_EXPRESS_PORT` (default: `5500`): EM Express port.
 * `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS, SYSTEM and PDBADMIN accounts.
 
-## Optional plugins
+## Optional plugin
 
-When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+When installed, this Vagrant project will make use of the following third party Vagrant plugin:
 
-* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
-variables from .env files;
 * [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
 proxies in the guest VM if you need to access the Internet through a proxy. See
 the plugin documentation for configuration.

--- a/OracleDatabase/21.3.0-XE/Vagrantfile
+++ b/OracleDatabase/21.3.0-XE/Vagrantfile
@@ -6,8 +6,7 @@
 # Since: July, 2018
 # Author: gerald.venzl@oracle.com
 # Description: Creates an Oracle database Vagrant virtual machine.
-# Optional plugins:
-#     vagrant-env (use .env files for configuration)
+# Optional plugin:
 #     vagrant-proxyconf (if you don't have direct access to the Internet)
 #         see https://github.com/tmatilai/vagrant-proxyconf for configuration
 #
@@ -16,6 +15,7 @@
 
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+require 'yaml'
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
@@ -29,9 +29,13 @@ ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
 
 # Define constants
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # Use vagrant-env plugin if available
-  if Vagrant.has_plugin?("vagrant-env")
-    config.env.load(".env.local", ".env") # enable the plugin
+  # Load configuration parameters into environment
+  ['config.local.yaml', 'config.yaml'].each do |f|
+    cfg = File.file?(f) ? YAML.safe_load_file(f, freeze: true) : {}
+    cfg && cfg.each do |key, value|
+      key = key.upcase
+      (!ENV[key] || ENV[key].empty?) && ENV[key] = value.to_s
+    end
   end
 
   # VM name

--- a/OracleDatabase/21.3.0-XE/config.yaml
+++ b/OracleDatabase/21.3.0-XE/config.yaml
@@ -1,37 +1,36 @@
+---
 # Oracle Database 21.3.0 Express Edition configuration file
 #
-# Requires vagrant-env plugin
-#
-# This file will be overwritten on updates, so it is recommended to make
-# a copy of this file called .env.local, then make changes in .env.local.
+# This file will be overwritten on updates, so it is recommended to make a copy
+# of this file called config.local.yaml, then make changes in config.local.yaml.
 #
 # To change a parameter, uncomment it and set it to the desired value.
 # All commented parameters will retain their default values.
 
 # VM name
-# VM_NAME='oracle21c-xe-vagrant'
+#VM_NAME: 'oracle21c-xe-vagrant'
 
 # Memory for the VM (in MB, 2300 MB is ~2.25 GB)
-# VM_MEMORY=2300
+#VM_MEMORY: 2300
 
 # VM time zone
 # If not specified, will be set to match host time zone (if possible)
 # Can use time zone name (e.g., 'America/Los_Angeles')
 # or an offset from GMT (e.g., 'Etc/GMT-2')
-# VM_SYSTEM_TIMEZONE=
+#VM_SYSTEM_TIMEZONE: ''
 
 # Save database installer RPM file for reuse when VM is rebuilt
-# VM_KEEP_DB_INSTALLER=false
+#VM_KEEP_DB_INSTALLER: false
 
 # Database character set
-# VM_ORACLE_CHARACTERSET='AL32UTF8'
+#VM_ORACLE_CHARACTERSET: 'AL32UTF8'
 
 # Listener port
-# VM_LISTENER_PORT=1521
+#VM_LISTENER_PORT: 1521
 
 # EM Express port
-# VM_EM_EXPRESS_PORT=5500
+#VM_EM_EXPRESS_PORT: 5500
 
 # Oracle Database password for SYS, SYSTEM and PDBADMIN accounts
 # If left blank, the password will be generated automatically
-# VM_ORACLE_PWD=
+#VM_ORACLE_PWD: ''

--- a/OracleDatabase/21.3.0/.gitignore
+++ b/OracleDatabase/21.3.0/.gitignore
@@ -1,1 +1,1 @@
-.env.local*
+config.local*.yaml

--- a/OracleDatabase/21.3.0/README.md
+++ b/OracleDatabase/21.3.0/README.md
@@ -4,9 +4,7 @@ This Vagrant project provisions Oracle Database automatically, using Vagrant, an
 
 ## Prerequisites
 
-1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
-2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
-makes configuration much easier
+Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
 
 ## Getting started
 
@@ -15,7 +13,7 @@ makes configuration much easier
 3. Download the installation zip file (`LINUX.X64_213000_db_home.zip`) from OTN into this directory - first time only:
 [http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html](http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html)
 4. Run `vagrant up`
-   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the VM to the latest via `yum`.
+   1. The first time you run this it will provision everything and may take a while. Ensure you have a good internet connection as the scripts will update the VM to the latest via `dnf`.
    2. The installation can be customized, if desired (see [Configuration](#configuration)).
 5. Connect to the database (see [Connecting to Oracle](#connecting-to-oracle))
 6. You can shut down the VM via the usual `vagrant halt` and then start it up again via `vagrant up`
@@ -55,14 +53,13 @@ There are three ways to set parameters:
 
 1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
 2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
-3. Use the `.env`/`.env.local` files (requires
-[vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
+3. Use the `config.yaml`/`config.local.yaml` files. You can configure your installation by editing the `config.yaml` file, but `config.yaml` will be overwritten on updates, so it's better to make a copy of `config.yaml` called `config.local.yaml`, then make changes in `config.local.yaml`. The `config.local.yaml` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
 
 Parameters are considered in the following order (first one wins):
 
 1. Environment variables
-2. `.env.local` (if it exists and the  [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
-3. `.env` (if the [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
+2. `config.local.yaml` (if it exists)
+3. `config.yaml`
 4. `Vagrantfile` definitions
 
 ### VM parameters
@@ -87,12 +84,10 @@ Parameters are considered in the following order (first one wins):
 * `VM_EM_EXPRESS_PORT` (default: `5500`): EM Express port.
 * `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS, SYSTEM and PDBADMIN accounts.
 
-## Optional plugins
+## Optional plugin
 
-When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+When installed, this Vagrant project will make use of the following third party Vagrant plugin:
 
-* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
-variables from .env files;
 * [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
 proxies in the guest VM if you need to access the Internet through a proxy. See
 the plugin documentation for configuration.

--- a/OracleDatabase/21.3.0/Vagrantfile
+++ b/OracleDatabase/21.3.0/Vagrantfile
@@ -6,8 +6,7 @@
 # Since: July, 2018
 # Author: gerald.venzl@oracle.com
 # Description: Creates an Oracle database Vagrant virtual machine.
-# Optional plugins:
-#     vagrant-env (use .env files for configuration)
+# Optional plugin:
 #     vagrant-proxyconf (if you don't have direct access to the Internet)
 #         see https://github.com/tmatilai/vagrant-proxyconf for configuration
 #
@@ -16,6 +15,7 @@
 
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+require 'yaml'
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
@@ -29,9 +29,13 @@ ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
 
 # Define constants
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # Use vagrant-env plugin if available
-  if Vagrant.has_plugin?("vagrant-env")
-    config.env.load(".env.local", ".env") # enable the plugin
+  # Load configuration parameters into environment
+  ['config.local.yaml', 'config.yaml'].each do |f|
+    cfg = File.file?(f) ? YAML.safe_load_file(f, freeze: true) : {}
+    cfg && cfg.each do |key, value|
+      key = key.upcase
+      (!ENV[key] || ENV[key].empty?) && ENV[key] = value.to_s
+    end
   end
 
   # VM name

--- a/OracleDatabase/21.3.0/config.yaml
+++ b/OracleDatabase/21.3.0/config.yaml
@@ -1,50 +1,49 @@
-# Oracle Database 12.2.0.1 configuration file
+---
+# Oracle Database 21.3.0 configuration file
 #
-# Requires vagrant-env plugin
-#
-# This file will be overwritten on updates, so it is recommended to make
-# a copy of this file called .env.local, then make changes in .env.local.
+# This file will be overwritten on updates, so it is recommended to make a copy
+# of this file called config.local.yaml, then make changes in config.local.yaml.
 #
 # To change a parameter, uncomment it and set it to the desired value.
 # All commented parameters will retain their default values.
 
 # VM name
-# VM_NAME='oracle-12201-vagrant'
+#VM_NAME: 'oracle-21c-vagrant'
 
-# Memory for the VM (in MB, 2048 MB = 2 GB)
-# VM_MEMORY=2048
+# Memory for the VM (in MB, 2560 MB = 2.5 GB)
+#VM_MEMORY: 2560
 
 # VM time zone
 # If not specified, will be set to match host time zone (if possible)
 # Can use time zone name (e.g., 'America/Los_Angeles')
 # or an offset from GMT (e.g., 'Etc/GMT-2')
-# VM_SYSTEM_TIMEZONE=
+#VM_SYSTEM_TIMEZONE: ''
 
 # Oracle base directory
-# VM_ORACLE_BASE='/opt/oracle'
+#VM_ORACLE_BASE: '/opt/oracle'
 
 # Oracle home directory
-# VM_ORACLE_HOME='/opt/oracle/product/12.2.0.1/dbhome_1'
+#VM_ORACLE_HOME: '/opt/oracle/product/21c/dbhome_1'
 
 # Oracle SID
-# VM_ORACLE_SID='ORCLCDB'
+#VM_ORACLE_SID: 'ORCLCDB'
 
 # PDB name
-# VM_ORACLE_PDB='ORCLPDB1'
+#VM_ORACLE_PDB: 'ORCLPDB1'
 
 # Database character set
-# VM_ORACLE_CHARACTERSET='AL32UTF8'
+#VM_ORACLE_CHARACTERSET: 'AL32UTF8'
 
 # Oracle Database edition
 # Valid values are 'EE' for Enterprise Edition or 'SE2' for Standard Edition 2
-# VM_ORACLE_EDITION='EE'
+#VM_ORACLE_EDITION: 'EE'
 
 # Listener port
-# VM_LISTENER_PORT=1521
+#VM_LISTENER_PORT: 1521
 
 # EM Express port
-# VM_EM_EXPRESS_PORT=5500
+#VM_EM_EXPRESS_PORT: 5500
 
 # Oracle Database password for SYS, SYSTEM and PDBADMIN accounts
 # If left blank, the password will be generated automatically
-# VM_ORACLE_PWD=
+#VM_ORACLE_PWD: ''

--- a/OracleDatabase/23ai-Free/.gitignore
+++ b/OracleDatabase/23ai-Free/.gitignore
@@ -1,2 +1,2 @@
 *.rpm
-.env.local*
+config.local*.yaml

--- a/OracleDatabase/23ai-Free/README.md
+++ b/OracleDatabase/23ai-Free/README.md
@@ -4,9 +4,7 @@ This Vagrant project provisions Oracle Database 23ai Free automatically, using V
 
 ## Prerequisites
 
-1. Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
-2. The [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is optional but
-makes configuration much easier
+Read the [prerequisites in the top level README](../../README.md#prerequisites) to set up Vagrant with either VirtualBox or KVM.
 
 ## Getting started
 
@@ -52,14 +50,13 @@ There are three ways to set parameters:
 
 1. Update the `Vagrantfile`. This is straightforward; the downside is that you will lose changes when you update this repository.
 2. Use environment variables. It might be difficult to remember the parameters used when the VM was instantiated.
-3. Use the `.env`/`.env.local` files (requires
-[vagrant-env](https://github.com/gosuri/vagrant-env) plugin). You can configure your installation by editing the `.env` file, but `.env` will be overwritten on updates, so it's better to make a copy of `.env` called `.env.local`, then make changes in `.env.local`. The `.env.local` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
+3. Use the `config.yaml`/`config.local.yaml` files. You can configure your installation by editing the `config.yaml` file, but `config.yaml` will be overwritten on updates, so it's better to make a copy of `config.yaml` called `config.local.yaml`, then make changes in `config.local.yaml`. The `config.local.yaml` file won't be overwritten when you update this repository and it won't mark your Git tree as changed (you won't accidentally commit your local configuration!).
 
 Parameters are considered in the following order (first one wins):
 
 1. Environment variables
-2. `.env.local` (if it exists and the  [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
-3. `.env` (if the [vagrant-env](https://github.com/gosuri/vagrant-env) plugin is installed)
+2. `config.local.yaml` (if it exists)
+3. `config.yaml`
 4. `Vagrantfile` definitions
 
 ### VM parameters
@@ -80,12 +77,10 @@ Parameters are considered in the following order (first one wins):
 * `VM_LISTENER_PORT` (default: `1521`): Listener port.
 * `VM_ORACLE_PWD` (default: automatically generated): Oracle Database password for the SYS, SYSTEM and PDBADMIN accounts. **Important: Database creation will fail if the password contains spaces or special characters.**
 
-## Optional plugins
+## Optional plugin
 
-When installed, this Vagrant project will make use of the following third party Vagrant plugins:
+When installed, this Vagrant project will make use of the following third party Vagrant plugin:
 
-* [vagrant-env](https://github.com/gosuri/vagrant-env): loads environment
-variables from .env files;
 * [vagrant-proxyconf](https://github.com/tmatilai/vagrant-proxyconf): set
 proxies in the guest VM if you need to access the Internet through a proxy. See
 the plugin documentation for configuration.

--- a/OracleDatabase/23ai-Free/Vagrantfile
+++ b/OracleDatabase/23ai-Free/Vagrantfile
@@ -6,8 +6,7 @@
 # Since: July, 2018
 # Author: gerald.venzl@oracle.com
 # Description: Creates an Oracle database Vagrant virtual machine.
-# Optional plugins:
-#     vagrant-env (use .env files for configuration)
+# Optional plugin:
 #     vagrant-proxyconf (if you don't have direct access to the Internet)
 #         see https://github.com/tmatilai/vagrant-proxyconf for configuration
 #
@@ -16,6 +15,7 @@
 
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+require 'yaml'
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
@@ -29,9 +29,13 @@ ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
 
 # Define constants
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # Use vagrant-env plugin if available
-  if Vagrant.has_plugin?("vagrant-env")
-    config.env.load(".env.local", ".env") # enable the plugin
+  # Load configuration parameters into environment
+  ['config.local.yaml', 'config.yaml'].each do |f|
+    cfg = File.file?(f) ? YAML.safe_load_file(f, freeze: true) : {}
+    cfg && cfg.each do |key, value|
+      key = key.upcase
+      (!ENV[key] || ENV[key].empty?) && ENV[key] = value.to_s
+    end
   end
 
   # VM name

--- a/OracleDatabase/23ai-Free/config.yaml
+++ b/OracleDatabase/23ai-Free/config.yaml
@@ -1,39 +1,38 @@
+---
 # Oracle Database 23ai Free configuration file
 #
-# Requires vagrant-env plugin
-#
-# This file will be overwritten on updates, so it is recommended to make
-# a copy of this file called .env.local, then make changes in .env.local.
+# This file will be overwritten on updates, so it is recommended to make a copy
+# of this file called config.local.yaml, then make changes in config.local.yaml.
 #
 # To change a parameter, uncomment it and set it to the desired value.
 # All commented parameters will retain their default values.
 
 # VM name
-# VM_NAME='oracle23ai-free-vagrant'
+#VM_NAME: 'oracle23ai-free-vagrant'
 
 # Memory for the VM (in MB, 2300 MB is ~2.25 GB)
-# VM_MEMORY=2300
+#VM_MEMORY: 2300
 
 # VM time zone
 # If not specified, will be set to match host time zone (if possible)
 # Can use time zone name (e.g., 'America/Los_Angeles')
 # or an offset from GMT (e.g., 'Etc/GMT-2')
-# VM_SYSTEM_TIMEZONE=
+#VM_SYSTEM_TIMEZONE: ''
 
 # Database version to install; default is the latest available
 # Must be one of the versions listed in the db_versions.csv file
-# VM_DB_VERSION='latest'
+#VM_DB_VERSION: 'latest'
 
 # Save database installer RPM file for reuse when VM is rebuilt
-# VM_KEEP_DB_INSTALLER=false
+#VM_KEEP_DB_INSTALLER: false
 
 # Database character set
-# VM_ORACLE_CHARACTERSET='AL32UTF8'
+#VM_ORACLE_CHARACTERSET: 'AL32UTF8'
 
 # Listener port
-# VM_LISTENER_PORT=1521
+#VM_LISTENER_PORT: 1521
 
 # Oracle Database password for SYS, SYSTEM and PDBADMIN accounts
 # If left blank, the password will be generated automatically
 # Database creation will fail if the password contains spaces or special characters
-# VM_ORACLE_PWD=
+#VM_ORACLE_PWD: ''


### PR DESCRIPTION
For the 9 single-instance database projects, switch from optionally using the vagrant-env plugin for configuration to optionally using YAML. The vagrant-env plugin is no longer maintained, and doesn't work correctly with Vagrant 2.4.3+ without modifying the dotenv gem. See #551.

The changes are the same for each project.

`.env`/`config.yaml`:

- rename `.env` to `config.yaml` and convert to YAML
- remove comment referring to the vagrant-env plugin
- update comment referring to `.env`/`.env.local` to refer to `config.yaml`/`config.local.yaml`

`.gitignore`:

- remove `.env.local*` and add `config.local*.yaml`

`README.md`:

- remove references to the vagrant-env plugin
- replace references to `.env`/`.env.local` with references to `config.yaml`/`config.local.yaml`

`Vagrantfile`:

- remove references to the vagrant-env plugin
- add `require 'yaml'`
- replace the code that loads environment variables from `.env` files with code that loads environment variables from `.yaml` files

Tested with both VirtualBox and libvirt providers.

Signed-off-by: Paul Neumann <38871902+PaulNeumann@users.noreply.github.com>