### PR TITLE
Use SHA256 to verify OracleDatabase/26ai installer

### DIFF
--- a/OracleDatabase/26ai/.gitattributes
+++ b/OracleDatabase/26ai/.gitattributes
@@ -1,2 +1,2 @@
 *.sh	text eol=lf
-*.cksum	text eol=lf
+*.sha256	text eol=lf

--- a/OracleDatabase/26ai/db_installer.cksum
+++ b/OracleDatabase/26ai/db_installer.cksum
@@ -1,1 +1,0 @@
-3314059017 2406058543 /vagrant/LINUX.X64_2326100_db_home.zip

--- a/OracleDatabase/26ai/db_installer.sha256
+++ b/OracleDatabase/26ai/db_installer.sha256
@@ -1,0 +1,1 @@
+2a5d2583df076209e624dff750829f9a562473c27c8f926d546cf9ad2a1a2efd */vagrant/LINUX.X64_2326100_db_home.zip

--- a/OracleDatabase/26ai/scripts/install.sh
+++ b/OracleDatabase/26ai/scripts/install.sh
@@ -21,15 +21,15 @@ echo 'INSTALLER: Verifying database installer file'
 
 db_installer=/vagrant/LINUX.X64_2326100_db_home.zip
 
-[[ $(cksum "$db_installer") == $(< /vagrant/db_installer.cksum) ]] || {
+sha256sum --check /vagrant/db_installer.sha256 || {
   cat << EOF
 
 INSTALLER: Database installer file missing or invalid.
            Destroy this VM (vagrant destroy), then
            make sure that the database installer file
            is in the same directory as the Vagrantfile,
-           and that its checksum and file size match
-           the values in the db_installer.cksum file,
+           and that its SHA-256 digest matches the
+           value in the db_installer.sha256 file,
            before running vagrant up again.
 
 EOF


### PR DESCRIPTION
Update the OracleDatabase/26ai project to use `sha256sum`, instead of `cksum`, to verify the database installer zip file. This change makes this project consistent with both the download page and the other single-instance database projects in this repository.

Tested with both VirtualBox and libvirt/KVM providers.

Closes #591.

Signed-off-by: Paul Neumann 38871902+PaulNeumann@users.noreply.github.com